### PR TITLE
Updates to dapp for the History controller support

### DIFF
--- a/Application.js
+++ b/Application.js
@@ -33,7 +33,7 @@ define(["require", "dcl/dcl", "delite/Stateful",
 				});
 			},
 
-			showOrHideViews: function (viewPath, viewParams) {
+			showOrHideViews: function (viewPath, viewParams, hash) {
 				// summary:
 				//		A convenience function to fire the dapp-display event to transition to a view,
 				// 		or a set of views.
@@ -46,7 +46,8 @@ define(["require", "dcl/dcl", "delite/Stateful",
 				var opts = {
 					bubbles: true,
 					cancelable: true,
-					dest: viewPath
+					dest: viewPath,
+					hash: hash
 				};
 				dcl.mix(opts,
 					viewParams ? viewParams : {

--- a/controllers/History.js
+++ b/controllers/History.js
@@ -1,0 +1,183 @@
+define(["require", "dcl/dcl", "dojo/on", "dojo/Deferred", "../utils/view",
+		"../utils/hash", "../Controller"
+	],
+	function (require, dcl, on, Deferred, viewUtils, hash, Controller) {
+		return dcl(Controller, {
+			// _currentPosition:     Integer
+			//              Persistent variable which indicates the current position/index in the history
+			//              (so as to be able to figure out whether the popState event was triggerd by
+			//              a backward or forward action).
+			_currentPosition: 0,
+
+			// currentState: Object
+			//              Current state
+			currentState: {},
+
+			constructor: function () {
+				this.docEvents = {
+					"dapp-finished-transition": this.finishedTransition
+				};
+				this.bind(window, "popstate", this.onPopState.bind(this));
+			},
+
+			finishedTransition: function (evt) {
+				// summary:
+				//		Response to dojox/app "startTransition" event.
+				//
+				// example:
+				//		|	event = {
+				//		|		"dest": event.dest,
+				//		|		"hash": event.hash,
+				//		|		"viewData": event.viewData,
+				//		|		"viewParams": event.viewParams,
+				//		|		"transition": event.transition
+				//		|	};
+				//		|	on.emit(document, "dapp-finished-transition", event);
+				//
+				// evt: Object
+				//		Transition options parameter
+				// if not doing a popState then setup the currentHash and call pushState with it.
+				if (evt && evt.doingPopState) { // when doingPopState do not pushState.
+					return;
+				}
+				//var currentHash = window.location.hash;
+				var evtdetail = {
+					"dest": evt.dest,
+					"hash": evt.hash,
+					"viewParams": evt.viewParams,
+					"viewData": evt.viewData,
+					"transition": evt.transition
+				};
+
+				// Create a new "current state" history entry
+				this._currentPosition += 1;
+				evtdetail.id = this._currentPosition;
+
+				var newDest = hash.getAllSelectedChildrenHash(this.app, "");
+				var newHash = evtdetail.hash || "#" + newDest;
+				if (newHash.charAt(0) !== "#") {
+					newHash = "#" + newHash;
+				}
+				evtdetail.dest = newDest; // replace dest with the dest for all selected children
+
+				if (evtdetail.viewParams) { // if there are viewParams add them to the hash
+					newHash = hash.buildWithViewParams(newHash, evtdetail.viewParams);
+				}
+
+				if (this.app.hideUrlHash) {
+					newHash = " "; // if hideUrlHash is true blank the hash in the url
+				}
+
+				evtdetail.fwdTransition = evtdetail.transition;
+				history.pushState(evtdetail, evtdetail.href, newHash);
+				this.currentState = Object.create(evtdetail);
+
+				// Finally: Publish pushState topic
+				on.emit(document, "dapp-pushState", evtdetail);
+			},
+
+			onPopState: function (evt) {
+				// summary:
+				//		Response to dojox/app "popstate" event.
+				//
+				// evt: Object
+				//		Transition options parameter
+
+				// Clean browser's cache and refresh the current page will trigger popState event,
+				// but in this situation the application has not started and throws an error.
+				// So we need to check application status, if application not STARTED, do nothing.
+				if ((this.app.status !== this.app.lifecycle.STARTED) || !evt.state) {
+					return;
+				}
+
+				var state = evt.state;
+				if (!state) {
+					if (window.location.hash) {
+						state = {
+							target: hash.getTarget(location.hash),
+							hash: location.hash,
+							viewParams: hash.getViewParams(location.hash)
+						};
+					} else {
+						state = {
+							target: this.app.defaultView
+						};
+					}
+				}
+
+				// Get direction of navigation and update _currentPosition accordingly
+				var backward = evt.state.id < this._currentPosition;
+				backward ? this._currentPosition -= 1 : this._currentPosition += 1;
+
+				//Need to compare evt.state.dest and this.currentState.dest to see if anything needs to be removed
+				var removeDest = this.getViewsToRemoveFromDest(evt.state.dest, this.currentState.dest);
+				var newDest = evt.state.dest;
+				if (removeDest) {
+					newDest = removeDest + "+" + newDest;
+				}
+
+				this.currentState = Object.create(evt.state);
+				// Publish popState topic and transition to the target view.
+				var opts = {
+					bubbles: true,
+					cancelable: true,
+					doingPopState: true,
+					dest: newDest,
+					viewParams: evt.state.viewParams,
+					viewData: evt.state.viewData,
+					reverse: backward ? true : false
+				};
+				dcl.mix(opts, {
+					transition: "slide",
+					direction: "end"
+				});
+				on.emit(document, "dapp-display", opts);
+
+				// Finally: Publish popState topic
+				on.emit(document, "dapp-popState", opts);
+			},
+
+			//TODO: question about removing the parent and the child view for example +leftParent,left1 when added adds
+			//TODO: both leftParent and left1, but -leftParent,left1 only hides left1, not leftParent, if you want to
+			//TODO: hide both you need to do -leftParent-leftParent,left1, so we do that on getViewsToRemoveFromDest
+			getViewsToRemoveFromDest: function (nextDest, prevDest) {
+				var removedDest = "";
+				if (nextDest && prevDest) {
+					var nextParts = nextDest.split("+");
+					var prevParts = prevDest.split("+");
+					for (var item in prevParts) {
+						if (nextParts.indexOf(prevParts[item]) === -1) {
+							var remTemp = prevParts[item]; // remTemp is the item not in the nextParts
+							// need to see if another view in nextParts has the same parentView and constraint
+							var remViewId = remTemp.replace(/,/g, "_");
+							var remView = viewUtils.getViewFromViewId(this.app, remViewId);
+							var removeView = true;
+							for (var item2 in nextParts) {
+								var nextViewId = nextParts[item2].replace(/,/g, "_");
+								var nextView = viewUtils.getViewFromViewId(this.app, nextViewId);
+								if (remView.parentView.id === nextView.parentView.id &&
+									remView.constraint === nextView.constraint) {
+									removeView = false;
+									break;
+								}
+							}
+							if (removeView) {
+								var remTemp2 = "";
+								var remTempParts = remTemp.split(",");
+								if (remTempParts.length > 1) {
+									for (var i = 0; i < remTempParts.length - 1; i++) {
+										remTemp2 = remTemp2 + "-" + remTempParts[i];
+									}
+									remTemp2 = remTemp2 + "-" + remTemp;
+									removedDest = removedDest + remTemp2;
+								} else {
+									removedDest = removedDest + "-" + prevParts[item];
+								}
+							}
+						}
+					}
+				}
+				return removedDest;
+			}
+		});
+	});

--- a/controllers/delite/Init.js
+++ b/controllers/delite/Init.js
@@ -109,14 +109,16 @@ define(["require", "dcl/dcl", "dojo/on", "dojo/Deferred", "dojo/_base/lang",
 				// fire the event on the container to load the main view
 				var displayDeferred = new Deferred();
 				// let's display default view
+				var initialView = this.app.alwaysUseDefaultView ? this.app.defaultView : this.app._startView;
+				var initialParams = this.app.alwaysUseDefaultView ? this.app.defaultParams : this.app._startParams;
 				on.emit(document, "dapp-display", {
 					// TODO is that really defaultView a good name? Shouldn't it be defaultTarget or defaultView_s_?
-					dest: this.app.defaultView,
+					dest: initialView,
+					viewParams: initialParams,
 					displayDeferred: displayDeferred,
 					bubbles: true,
 					cancelable: true
 				});
-				// TODO views in the hash MUST be handled by history controller?
 				if (this.app) {
 					displayDeferred.then(function () {
 						this.app.status = this.app.lifecycle.STARTED;

--- a/controllers/delite/Load.js
+++ b/controllers/delite/Load.js
@@ -37,10 +37,8 @@ define(
 				if (!event.dapp || !event.dapp.parentView) {
 					//This must be a direct call from .show or .hide, need to setup event.dapp with parentView etc.
 					event.dapp = this._setupEventDapp(event);
-					if (event.dapp.callTransition) {
-						this._handleShowFromDispContainer(event, event.dapp.dest);
-						return;
-					}
+					this._handleShowFromDispContainer(event, event.dapp.dest);
+					return;
 				}
 
 				var viewId = event.dapp.parentView !== this.app ?
@@ -87,33 +85,13 @@ define(
 				dest = viewId.replace(/_/g, ",");
 				event.dapp = {};
 
-				// if dest without defaults added is already nested call _handleShowFromDispContainer
-				if (dest.indexOf("+") >= 0 || dest.indexOf("-") >= 0 || dest.indexOf(",") >= 0) {
-					if (event.hide) {
-						dest = "-" + dest;
-					}
-					event.dapp.callTransition = true;
-					event.dapp.dest = dest;
-					return event.dapp;
-				}
-				//	var viewPaths = this.app._getViewPaths(dest);
-				var viewPaths = viewUtils._getViewPaths(this.app, dest);
-				event.dest = viewPaths[0].dest;
+				// Note at one point this code would not set callTransition = true for a single view but in that
+				// case the history controller would not be notified of the transition, so it was changed to always
+				// call Transition so the flag is no longer needed.
 				if (event.hide) {
 					dest = "-" + dest;
 				}
-				// if viewPaths have multiple parts or dest and defaults is nested call _handleShowFromDispContainer
-				if (viewPaths.length > 1 || event.dest.indexOf(",") >= 0) {
-					event.dapp.callTransition = true;
-					event.dapp.dest = dest;
-					//	this._handleShowFromDispContainer(event, dest);
-					return event.dapp;
-				}
-				// Can process this direct call to .show or .hide since it is not multipart or nested
-				event.dapp.parentNode = event.target;
-				event.dapp.viewPath = viewPaths[0]; // viewPaths[0]
-				event.dapp.parentView = viewUtils.getParentViewFromViewName(this.app, event.dest, event.target);
-				event.dapp.isParent = false;
+				event.dapp.dest = dest;
 				return event.dapp;
 			},
 

--- a/controllers/delite/Transition.js
+++ b/controllers/delite/Transition.js
@@ -1,5 +1,5 @@
-define(["dcl/dcl", "dojo/when", "dojo/Deferred", "dojo/promise/all", "../../Controller", "../../utils/view"],
-	function (dcl, when, Deferred, all, Controller, viewUtils) {
+define(["dcl/dcl", "dojo/when", "dojo/Deferred", "dojo/promise/all", "dojo/on", "../../Controller", "../../utils/view"],
+	function (dcl, when, Deferred, all, on, Controller, viewUtils) {
 
 		// summary:
 		//		A Transition controller to listen for "dapp-display" events and drive the transitions for those
@@ -48,12 +48,15 @@ define(["dcl/dcl", "dojo/when", "dojo/Deferred", "dojo/promise/all", "../../Cont
 				// event: Object
 				//		"app-transition" event parameter. It should include dest, like: {"dest": viewId}
 				var dest = event.dest;
+				var hash = event.hash;
 				this._handleMultipleViewParts({
 					dest: dest,
+					hash: hash,
 					viewData: event.viewData,
 					reverse: event.reverse,
 					transition: event.transition,
 					displayDeferred: event.displayDeferred,
+					doingPopState: event.doingPopState,
 					viewParams: event.viewParams,
 					dapp: {}
 				});
@@ -111,6 +114,14 @@ define(["dcl/dcl", "dojo/when", "dojo/Deferred", "dojo/promise/all", "../../Cont
 					}
 					// check for all defs being complete here, and resolve displayDeferred when all are resolved
 					all(defs).then(function (value) {
+						//	event.detail = {
+						//		"dest": event.dest,
+						//		"hash": event.hash,
+						//		"viewData": event.viewData,
+						//		"viewParams": event.viewParams,
+						//		"transition": event.transition
+						//	};
+						on.emit(document, "dapp-finished-transition", event);
 						if (event.displayDeferred) {
 							event.displayDeferred.resolve(value);
 						}

--- a/tests/functional/simple1/config.json
+++ b/tests/functional/simple1/config.json
@@ -13,7 +13,8 @@
 		"dapp/controllers/delite/Init",
 		"dapp/controllers/Logger",
 		"dapp/controllers/delite/Load",
-		"dapp/controllers/delite/Transition"
+		"dapp/controllers/delite/Transition",
+		"dapp/controllers/History"
 	],
 
 	"dependencies": [
@@ -32,6 +33,7 @@
 
 	"parseOnLoad": true,
 
+	"alwaysUseDefaultView" : true, // ignore any url hash when starting the app
 	"defaultView": "header1+center1+footer1",
 	"views": {
 		"header1": {

--- a/tests/unit/all.js
+++ b/tests/unit/all.js
@@ -10,5 +10,6 @@ define([
 	"./multipleAndNestedViewsActivateCalls/Test",
 	"./multipleAndNestedViewsActivateCalls/TestConstraints",
 	"./sidePaneViewsActivateCalls/Test",
+	"./historyController/Test",
 	"./dstoreMemory/Test"
 ]);

--- a/tests/unit/appStatus/app.json
+++ b/tests/unit/appStatus/app.json
@@ -27,6 +27,7 @@
 	},
 
 	//TODO: There is a problem with using duplicate view names across tests, getting duplicate view error!!!
+	"alwaysUseDefaultView" : true, // ignore any url hash when starting the app
 	"defaultView": "appStatusApp1Home1+appStatusApp1Home2+appStatusApp1Home3NoController",
 	"views": {
 		"appStatusApp1Home1": {

--- a/tests/unit/dstoreMemory/app.json
+++ b/tests/unit/dstoreMemory/app.json
@@ -43,6 +43,7 @@
 		"logTimeStamp": 0
 	},
 
+	"alwaysUseDefaultView" : true, // ignore any url hash when starting the app
 	"defaultView": "dstoreMemoryAppHome1",
 	"views": {
 		"dstoreMemoryAppHome1": {

--- a/tests/unit/hideView/app.json
+++ b/tests/unit/hideView/app.json
@@ -29,7 +29,7 @@
 
 	"parseOnLoad": true,
 
-	//TODO: There is a problem with using duplicate view names across tests, getting duplicate view error!!!
+	"alwaysUseDefaultView" : true, // ignore any url hash when starting the app
 	"defaultView": "hideViewApp3Home1",
 	"views": {
 		"hideViewApp3Home1": {

--- a/tests/unit/historyController/Test.js
+++ b/tests/unit/historyController/Test.js
@@ -1,0 +1,750 @@
+// quotmark:false needed for the inline html
+// jshint quotmark:false
+define([
+	"intern!object",
+	"intern/chai!assert",
+	"dapp/Application",
+	"dapp/utils/view",
+	"dapp/utils/hash",
+	"dojo/json",
+	"dojo/topic",
+	"dojo/on",
+	"dojo/dom-geometry",
+	"dojo/dom-class",
+	"delite/register",
+	"dojo/Deferred",
+	"requirejs-text/text!dapp/tests/unit/historyController/app1.json",
+	"deliteful/LinearLayout",
+	"deliteful/ViewStack"
+], function (registerSuite, assert, Application, viewUtils, hash, json, topic, on, domGeom, domClass, register,
+	Deferred, historyControllerconfig1) {
+	// -------------------------------------------------------------------------------------- //
+	// for historyControllerSuite1 transition test
+	var historyControllerContainer1, historyControllerNode1;
+	var historyControllerHtmlContent1 =
+		'<div style="position: relative; height: 500px"> ' +
+		'	<d-side-pane mode="push" position="start" id="hc1leftPane" style="background-color: lavender;">' +
+		'</d-side-pane>' +
+		'	<d-linear-layout style="width:100%; height: 100%">' +
+		'		<d-view-stack id="hc1headerViewStack" style="width: 100%; height: 10%;"></d-view-stack>' +
+		'		<d-linear-layout id="hc1centerLinearLayout" style="width:100%; height: 100%" vertical="false">' +
+		'</d-linear-layout>' +
+		'		<d-view-stack id="hc1footerViewStack" style="width: 100%; height: 10%;"></d-view-stack>' +
+		'	</d-linear-layout>' +
+		'<d-side-pane mode="push" position="end" id="hc1rightPane"  style="background-color: lightgoldenrodyellow;">' +
+		'</d-side-pane>' +
+		'</div>';
+
+	var testApp = null;
+	var hc1right1View = null;
+	var hc1header1View = null;
+	var hc1center1View = null;
+	var hc1footer1View = null;
+	var hc1left2View = null;
+	var hc1leftParentView = null;
+
+	var historyControllerSuite1 = {
+		name: "historyControllerSuite1: test app transitions",
+		setup: function () {
+
+			historyControllerContainer1 = document.createElement("div");
+			document.body.appendChild(historyControllerContainer1);
+			historyControllerContainer1.innerHTML = historyControllerHtmlContent1;
+			register.parse(historyControllerContainer1);
+			historyControllerNode1 =
+				document.getElementById("historyControllerApp1linearlayout");
+
+
+		},
+		"historyController test initial view": function () {
+			//	var d = this.async(10000);
+			this.timeout = 10000;
+			return new Application(json.parse(stripComments(historyControllerconfig1)),
+				historyControllerContainer1).then(function (app) {
+				// we are ready to test
+				testApp = app;
+
+				//verify these are showing "defaultView": "hc1header1+hc1centerParent+hc1center1+hc1right1+hc1footer1",
+
+				hc1header1View = viewUtils.getViewFromViewId(testApp, "hc1header1");
+				hc1center1View = viewUtils.getViewFromViewId(testApp, "hc1center1");
+				hc1right1View = viewUtils.getViewFromViewId(testApp, "hc1right1");
+				hc1footer1View = viewUtils.getViewFromViewId(testApp, "hc1footer1");
+				checkActivateCallCount(hc1header1View, 1);
+			}).then(function () {
+				var hc1header1content = hc1header1View.containerNode;
+				assert.isNotNull(hc1header1content, "hc1header1content must be here");
+			}).then(function () {
+				var hc1center1content = hc1header1View.containerNode;
+				checkActivateCallCount(hc1center1View, 1);
+				assert.isNotNull(hc1center1content, "hc1center1 must be here");
+				checkNodeVisibile(hc1center1content);
+			}).then(function () {
+				var hc1right1content = hc1right1View.containerNode;
+				checkActivateCallCount(hc1right1View, 1);
+				assert.isNotNull(hc1right1content, "hc1right1content must be here");
+				checkNodeVisibile(hc1right1content);
+
+				var hc1footer1content = hc1footer1View.containerNode;
+				checkActivateCallCount(hc1footer1View, 1);
+				assert.isNotNull(hc1footer1content, "hc1footer1content must be here");
+
+			}).then(function () {
+				var currentHash = window.location.hash;
+				assert.deepEqual(currentHash, "#hc1header1+hc1centerParent+hc1center1+hc1right1+hc1footer1",
+					" currentHash should be #hc1header1+hc1centerParent+hc1center1+hc1right1+hc1footer1");
+			});
+		},
+		// Currently showing hc1header1+hc1centerParent+hc1center1+hc1right1+hc1footer1 test
+		// showOrHideViews('hc1center2'
+		"show hc1center2 with testApp.showOrHideViews('hc1center2')": function () {
+			this.timeout = 10000;
+			var displayDeferred = new Deferred();
+			testApp.showOrHideViews('hc1center2', {
+				displayDeferred: displayDeferred
+			});
+			return displayDeferred.then(function () {
+				var hc1center2content = document.getElementById("hc1center2");
+				var hc1center2View = viewUtils.getViewFromViewId(testApp, "hc1center2");
+				checkNodeVisibile(hc1center2content);
+				checkActivateCallCount(hc1center2View, 1, true);
+			}).then(function () {
+				var currentHash = window.location.hash;
+				assert.deepEqual(currentHash, "#hc1header1+hc1centerParent+hc1center2+hc1right1+hc1footer1",
+					" currentHash should be #hc1header1+hc1centerParent+hc1center2+hc1right1+hc1footer1");
+			});
+		},
+		// Currently showing hc1header1+hc1centerParent+hc1center2+hc1right1+hc1footer1 test
+		// showOrHideViews('hc1center3' with viewParams for hclcenter3
+		"show hc1center3 with testApp.showOrHideViews('hc1center3', viewParams for hclcenter3)": function () {
+			this.timeout = 10000;
+			var displayDeferred = new Deferred();
+			var params = {
+				displayDeferred: displayDeferred,
+				"viewParams": {
+					"views": {
+						"hc1center3": {
+							'pTestVal1': "value1"
+						}
+					}
+				}
+			};
+			testApp.showOrHideViews('hc1center3', params);
+			return displayDeferred.then(function () {
+				var hc1center3content = document.getElementById("hc1center3");
+				var hc1center3View = viewUtils.getViewFromViewId(testApp, "hc1center3");
+				checkNodeVisibile(hc1center3content);
+				checkActivateCallCount(hc1center3View, 1, true);
+			}).then(function () {
+				var currentHash = window.location.hash;
+				assert.deepEqual(currentHash,
+					"#hc1header1+hc1centerParent+(hc1center3&pTestVal1=value1)+hc1right1+hc1footer1",
+					" currentHash should include (hc1center3&pTestVal1=value1)+hc1right1+hc1footer1");
+			});
+		},
+		// Currently showing hc1header1+hc1centerParent+hc1center3+hc1right1+hc1footer1 test
+		// history.back()
+		"test history.back() to get back to hc1center2)": function () {
+			this.timeout = 10000;
+			var displayDeferred = new Deferred();
+			setupOnOnce(displayDeferred);
+			history.back();
+			return displayDeferred.then(function () {
+				var hc1center2content = document.getElementById("hc1center2");
+				var hc1center2View = viewUtils.getViewFromViewId(testApp, "hc1center2");
+				checkNodeVisibile(hc1center2content);
+				checkActivateCallCount(hc1center2View, 2, true);
+			}).then(function () {
+				var currentHash = window.location.hash;
+				assert.deepEqual(currentHash, "#hc1header1+hc1centerParent+hc1center2+hc1right1+hc1footer1",
+					" currentHash should be #hc1header1+hc1centerParent+hc1center2+hc1right1+hc1footer1");
+			});
+		},
+		// Currently showing hc1header1+hc1centerParent+hc1center2+hc1right1+hc1footer1 test
+		// history.back()
+		"test history.back() to get back to hc1center1)": function () {
+			this.timeout = 10000;
+			var displayDeferred = new Deferred();
+			setupOnOnce(displayDeferred);
+			history.back();
+			return displayDeferred.then(function () {
+				var hc1center1content = document.getElementById("hc1center1");
+				var hc1center1View = viewUtils.getViewFromViewId(testApp, "hc1center1");
+				checkNodeVisibile(hc1center1content);
+				checkActivateCallCount(hc1center1View, 2, true);
+			}).then(function () {
+				var currentHash = window.location.hash;
+				assert.deepEqual(currentHash, "#hc1header1+hc1centerParent+hc1center1+hc1right1+hc1footer1",
+					" currentHash should be #hc1header1+hc1centerParent+hc1center1+hc1right1+hc1footer1");
+			});
+		},
+		// Currently showing hc1header1+hc1centerParent+hc1center1+hc1right1+hc1footer1 test
+		// history.forward()
+		"test history.forward() to get to hc1center2)": function () {
+			this.timeout = 10000;
+			var displayDeferred = new Deferred();
+			setupOnOnce(displayDeferred);
+			history.forward();
+			return displayDeferred.then(function () {
+				var hc1center2content = document.getElementById("hc1center2");
+				var hc1center2View = viewUtils.getViewFromViewId(testApp, "hc1center2");
+				checkNodeVisibile(hc1center2content);
+				checkActivateCallCount(hc1center2View, 3, true);
+			}).then(function () {
+				var currentHash = window.location.hash;
+				assert.deepEqual(currentHash, "#hc1header1+hc1centerParent+hc1center2+hc1right1+hc1footer1",
+					" currentHash should be #hc1header1+hc1centerParent+hc1center2+hc1right1+hc1footer1");
+			});
+		},
+		// Currently showing hc1header1+hc1centerParent+hc1center2+hc1right1+hc1footer1 test
+		// history.forward()
+		"test history.forward() to get to hc1center3)": function () {
+			this.timeout = 11000;
+			var displayDeferred = new Deferred();
+			setupOnOnce(displayDeferred);
+			history.forward();
+			return displayDeferred.then(function () {
+				var hc1center3content = document.getElementById("hc1center3");
+				var hc1center3View = viewUtils.getViewFromViewId(testApp, "hc1center3");
+				checkNodeVisibile(hc1center3content);
+				checkActivateCallCount(hc1center3View, 2, true);
+			}).then(function () {
+				var currentHash = window.location.hash;
+				assert.deepEqual(currentHash,
+					"#hc1header1+hc1centerParent+(hc1center3&pTestVal1=value1)+hc1right1+hc1footer1",
+					" currentHash should include (hc1center3&pTestVal1=value1)+hc1right1+hc1footer1");
+			});
+		},
+		// Currently showing hc1header1+hc1centerParent+hc1center3+hc1right1+hc1footer1 test
+		// showOrHideViews('-hc1right1'
+		"Hide hc1right1 with testApp.showOrHideViews('-hc1right1')": function () {
+			this.timeout = 10000;
+			var displayDeferred = new Deferred();
+			testApp.showOrHideViews('-hc1right1', {
+				displayDeferred: displayDeferred
+			});
+			return displayDeferred.then(function () {
+				var hc1rightPane = document.getElementById("hc1rightPane");
+				assert.isTrue(hc1rightPane.style.display === "none");
+				checkActivateCallCount(hc1right1View, 5, true);
+				checkDeactivateCallCount(hc1right1View, 5, true);
+			});
+		},
+		// Currently showing #hc1header1+hc1centerParent+hc1center3+hc1footer1 test
+		// history.back()
+		"test history.back() to get back to hc1right1)": function () {
+			this.timeout = 10000;
+			var displayDeferred = new Deferred();
+			setupOnOnce(displayDeferred);
+			history.back();
+			return displayDeferred.then(function () {
+				var hc1rightPane = document.getElementById("hc1rightPane");
+				assert.isFalse(hc1rightPane.style.display === "none");
+				checkActivateCallCount(hc1right1View, 6, true);
+				checkDeactivateCallCount(hc1right1View, 5, true);
+			}).then(function () {
+				var currentHash = window.location.hash;
+				assert.deepEqual(currentHash,
+					"#hc1header1+hc1centerParent+(hc1center3&pTestVal1=value1)+hc1right1+hc1footer1",
+					" currentHash should include (hc1center3&pTestVal1=value1)+hc1right1+hc1footer1");
+			});
+		},
+		// Currently showing #hc1header1+hc1centerParent+(hc1center3&pTestVal1=value1)+hc1right1+hc1footer1 test
+		// history.forward()
+		"test history.forward() to hide hc1right1)": function () {
+			this.timeout = 10000;
+			var displayDeferred = new Deferred();
+			setupOnOnce(displayDeferred);
+			history.forward();
+			return displayDeferred.then(function () {
+				var hc1rightPane = document.getElementById("hc1rightPane");
+				assert.isTrue(hc1rightPane.style.display === "none");
+				checkActivateCallCount(hc1right1View, 6, true);
+				checkDeactivateCallCount(hc1right1View, 6, true);
+			}).then(function () {
+				var currentHash = window.location.hash;
+				assert.deepEqual(currentHash, "#hc1header1+hc1centerParent+hc1center3+hc1footer1",
+					" currentHash should be #hc1header1+hc1centerParent+hc1center3+hc1footer1");
+			});
+		},
+		// Currently showing #hc1header1+hc1centerParent+hc1center3+hc1footer1 test
+		// showOrHideViews('leftParent,left1'
+		"show hc1left1 with testApp.showOrHideViews('hc1leftParent,hc1left1')": function () {
+			this.timeout = 10000;
+			var displayDeferred = new Deferred();
+			var viewParams = {
+				displayDeferred: displayDeferred,
+				"viewParams": {
+					'pTestVal': "value1"
+				}
+			};
+			testApp.showOrHideViews('hc1leftParent,hc1left1', viewParams);
+			return displayDeferred.then(function () {
+				var hc1left1content = document.getElementById("hc1leftParent_hc1left1");
+				var hc1left1View = viewUtils.getViewFromViewId(testApp, "hc1leftParent_hc1left1");
+				checkNodeVisibile(hc1left1content);
+				checkActivateCallCount(hc1left1View, 1, true);
+				assert.deepEqual(hc1left1View.viewParams.pTestVal, "value1",
+					" hc1left1View.viewParams.pTestVal should equal value1");
+				//	assert.deepEqual(hc1leftParentView.viewParams.pTestVal, "value1",
+				//		" hc1leftParentView.viewParams.pTestVal should equal value1");
+			}).then(function () {
+				var currentHash = window.location.hash;
+				assert.deepEqual(currentHash,
+					"#hc1header1+hc1centerParent+hc1center3+hc1footer1+hc1leftParent,hc1left1&pTestVal=value1",
+					" currentHash should have &pTestVal=value1");
+			});
+		},
+		// Currently showing #hc1header1+hc1centerParent+hc1center3+hc1footer1+hc1leftParent,hc1left1&pTestVal=value1
+		// test showOrHideViews('-hc1leftParent') when I used showOrHideViews('-hc1leftParent-hc1leftParent,left1') it
+		// got a warning because hc1leftParent was not found as the parent of left1
+		"Hide hc1left1 with testApp.showOrHideViews('-hc1leftParent')": function () {
+			this.timeout = 10000;
+			var displayDeferred = new Deferred();
+			testApp.showOrHideViews('-hc1leftParent', {
+				displayDeferred: displayDeferred
+			});
+			return displayDeferred.then(function () {
+				//var hc1rightPane = document.getElementById("hc1rightPane");
+				var hc1left1content = document.getElementById("hc1leftPane");
+				var hc1left1View = viewUtils.getViewFromViewId(testApp, "hc1leftParent_hc1left1");
+				assert.isTrue(hc1left1content.style.display === "none");
+				checkActivateCallCount(hc1left1View, 1, true);
+				checkDeactivateCallCount(hc1left1View, 1, true);
+			});
+		},
+		// Currently showing hc1header1+hc1centerParent+hc1center1+hc1footer1 test
+		// hc1rightPaneElem.show('hc1right2')
+		"show hc1right2 with hc1rightPaneElem.show('hc1right2')": function () {
+			this.timeout = 10000;
+			var hc1rightPaneElem = document.getElementById("hc1rightPane");
+			//Note: at one point calls to .show or .hide did not update the url hash unless the view has a +, - or ,
+			//but that was changed so that the history controller could handle those cases too.
+			return hc1rightPaneElem.show('hc1right2').then(function () {
+				var hc1right2View = viewUtils.getViewFromViewId(testApp, "hc1right2");
+				checkActivateCallCount(hc1right2View, 1);
+				var hc1right2content = hc1right2View.containerNode;
+				assert.isNotNull(hc1right2content, "hc1right2content must be here");
+				checkNodeVisibile(hc1right2content);
+			});
+		},
+		// Currently showing #hc1header1+hc1centerParent+hc1center3+hc1footer1+hc1right2 test
+		// hc1rightPaneElem.hide('hc1right2')
+		"hide hc1right2 with hc1rightPaneElem.hide('hc1right2')": function () {
+			this.timeout = 10000;
+			var hc1rightPaneElem = document.getElementById("hc1rightPane");
+			return hc1rightPaneElem.hide('hc1right2').then(function () {
+				var hc1right2View = viewUtils.getViewFromViewId(testApp, "hc1right2");
+				checkDeactivateCallCount(hc1right2View, 1);
+				var hc1right2content = hc1right2View.containerNode;
+				assert.isNotNull(hc1right2content, "hc1right2content must be here");
+				//	checkNodeVisibile(hc1right2content);
+				assert.isTrue(hc1right2View.domNode.style.display === "none");
+				assert.isTrue(hc1rightPaneElem.style.display === "none");
+			});
+		},
+		// Currently showing #hc1header1+hc1centerParent+hc1center3+hc1footer1 test
+		// showOrHideViews('leftParent,left2'
+		"show hc1left2 - testApp.showOrHideViews('hc1leftParent,hc1left2' with parent and child params)": function () {
+			this.timeout = 10000;
+			var displayDeferred = new Deferred();
+			var params = {
+				displayDeferred: displayDeferred,
+				"viewParams": {
+					"views": {
+						"hc1leftParent": {
+							'pTestVal2': "parentVal2"
+						},
+						"hc1leftParent,hc1left2": {
+							'pTestVal1': "value2",
+							'pHideObjTest1': {
+								"obj1": "value2"
+							}
+						}
+					},
+					'pTestVal': "value2",
+					'pHideObjTest2': {
+						"obj1": "value2"
+					}
+
+				}
+			};
+			testApp.showOrHideViews('hc1leftParent,hc1left2', params);
+			return displayDeferred.then(function () {
+				var hc1left2content = document.getElementById("hc1leftParent_hc1left2");
+				hc1left2View = viewUtils.getViewFromViewId(testApp, "hc1leftParent_hc1left2");
+				hc1leftParentView = viewUtils.getViewFromViewId(testApp, "hc1leftParent");
+				checkNodeVisibile(hc1left2content);
+				checkActivateCallCount(hc1left2View, 1, true);
+				assert.deepEqual(hc1left2View.viewParams.pTestVal, "value2",
+					" hc1left2View.viewParams.pTestVal should equal value2");
+				assert.deepEqual(hc1left2View.viewParams.pTestVal2, "parentVal2",
+					" hc1left2View.viewParams.pTestVal2 should equal parentVal2 mixed in from parent view");
+				assert.deepEqual(hc1leftParentView.viewParams.pTestVal2, "parentVal2",
+					" hc1leftParentView.viewParams.pTestVal2 should equal parentVal2");
+			}).then(function () {
+				var currentHash = window.location.hash;
+				// var t is when the child view params come before the parent
+				//var t = "#hc1header1+hc1centerParent+hc1center3+hc1footer1+((hc1leftParent&pTestVal2=parentVal2)," +
+				//	"hc1left2&pTestVal1=value2)&pTestVal=value2";
+				var t2 = "#hc1header1+hc1centerParent+hc1center3+hc1footer1+(hc1leftParent&pTestVal2=parentVal2)," +
+					"(hc1left2&pTestVal1=value2)&pTestVal=value2";
+				assert.deepEqual(currentHash, t2,
+					" currentHash should have (hc1leftParent,hc1left2&pTestVal1=value2) and &pTestVal=value1");
+			});
+		},
+		// Currently showing #hc1header1+hc1centerParent+hc1center3+hc1footer1+hc1leftParent,hc1left2" test
+		// showOrHideViews('leftParent,left1'
+		"show hc1left1 with testApp.showOrHideViews('hc1leftParent,hc1left1' with hideUrlHash true)": function () {
+			this.timeout = 10000;
+			var displayDeferred = new Deferred();
+			var params = {
+				displayDeferred: displayDeferred,
+				"viewParams": {
+					"views": {
+						"hc1leftParent": {
+							'pTestVal1': "parentVal1"
+						},
+						"hc1leftParent,hc1left1": {
+							'pTestVal1': "value1"
+						}
+					},
+					'pTestVal': "value1"
+
+				}
+			};
+			testApp.hideUrlHash = true;
+			testApp.showOrHideViews('hc1leftParent,hc1left1', params);
+			return displayDeferred.then(function () {
+				var hc1left1content = document.getElementById("hc1leftParent_hc1left1");
+				var hc1left1View = viewUtils.getViewFromViewId(testApp, "hc1leftParent_hc1left1");
+				var hc1leftParentView = viewUtils.getViewFromViewId(testApp, "hc1leftParent");
+				checkNodeVisibile(hc1left1content);
+				checkActivateCallCount(hc1left1View, 2, true);
+				assert.deepEqual(hc1left1View.viewParams.pTestVal, "value1",
+					" hc1left1View.viewParams.pTestVal should equal value1");
+				assert.deepEqual(hc1left1View.viewParams.pTestVal1, "value1",
+					" hc1left1View.viewParams.pTestVal1 should equal value1 from the child !mixed from parent view");
+				assert.deepEqual(hc1leftParentView.viewParams.pTestVal1, "parentVal1",
+					" hc1leftParentView.viewParams.pTestVal1 should equal parentVal1");
+			}).then(function () {
+				var currentHash = window.location.hash;
+				assert.deepEqual(currentHash, "",
+					" currentHash should be empty");
+			});
+		},
+		// Currently showing #hc1header1+hc1centerParent+hc1center3+hc1footer1+hc1leftParent,hc1left1" test
+		// history.back()
+		"test history.back() to get back to hc1leftParent,hc1left2)": function () {
+			this.timeout = 10000;
+			var displayDeferred = new Deferred();
+			setupOnOnce(displayDeferred);
+			history.back();
+			return displayDeferred.then(function () {
+				var hc1left2content = document.getElementById("hc1leftParent_hc1left2");
+				//var hc1left2View = viewUtils.getViewFromViewId(testApp, "hc1leftParent_hc1left2");
+				//var hc1leftParentView = viewUtils.getViewFromViewId(testApp, "hc1leftParent");
+				checkNodeVisibile(hc1left2content);
+				checkActivateCallCount(hc1left2View, 2, true);
+				assert.deepEqual(hc1left2View.viewParams.pTestVal, "value2",
+					" hc1left2View.viewParams.pTestVal should equal value2");
+				assert.deepEqual(hc1left2View.viewParams.pTestVal2, "parentVal2",
+					" hc1left2View.viewParams.pTestVal2 should equal parentVal2 mixed in from parent view");
+				assert.deepEqual(hc1leftParentView.viewParams.pTestVal2, "parentVal2",
+					" hc1leftParentView.viewParams.pTestVal2 should equal parentVal2");
+			}).then(function () {
+				var currentHash = window.location.hash;
+				var t2 = "#hc1header1+hc1centerParent+hc1center3+hc1footer1+(hc1leftParent&pTestVal2=parentVal2)," +
+					"(hc1left2&pTestVal1=value2)&pTestVal=value2";
+				assert.deepEqual(currentHash, t2,
+					" currentHash should have (hc1leftParent,hc1left2&pTestVal1=value2) and &pTestVal=value1");
+			});
+		},
+		// Currently showing #hc1header1+hc1centerParent+hc1center3+hc1footer1+hc1leftParent,hc1left1" test
+		// history.forward()
+		"test history.forward() to get back to hc1leftParent,hc1left1 with parent and child params)": function () {
+			this.timeout = 10000;
+			var displayDeferred = new Deferred();
+			setupOnOnce(displayDeferred);
+			history.forward();
+			return displayDeferred.then(function () {
+				var hc1left1content = document.getElementById("hc1leftParent_hc1left1");
+				var hc1left1View = viewUtils.getViewFromViewId(testApp, "hc1leftParent_hc1left1");
+				var hc1leftParentView = viewUtils.getViewFromViewId(testApp, "hc1leftParent");
+				checkNodeVisibile(hc1left1content);
+				checkActivateCallCount(hc1left1View, 3, true);
+				assert.deepEqual(hc1left1View.viewParams.pTestVal, "value1",
+					" hc1left1View.viewParams.pTestVal should equal value1");
+				assert.deepEqual(hc1left1View.viewParams.pTestVal1, "value1",
+					" hc1left1View.viewParams.pTestVal1 should equal value1 from the child !mixed from parent view");
+				assert.deepEqual(hc1leftParentView.viewParams.pTestVal1, "parentVal1",
+					" hc1leftParentView.viewParams.pTestVal1 should equal parentVal1");
+			}).then(function () {
+				var currentHash = window.location.hash;
+				assert.deepEqual(currentHash, "",
+					" currentHash should be empty");
+			});
+		},
+		// Currently showing #hc1header1+hc1centerParent+hc1center3+hc1footer1+hc1leftParent,hc1left1" test
+		// showOrHideViews('leftParent,left2' with viewData
+		"show hc1left2 testApp.showOrHideViews('hc1leftParent,hc1left2' with parent and child viewData)": function () {
+			this.timeout = 10000;
+			var displayDeferred = new Deferred();
+			var params = {
+				displayDeferred: displayDeferred,
+				"viewData": {
+					"views": {
+						"hc1leftParent": {
+							'pTestVal2': "parentVal2"
+						},
+						"hc1leftParent,hc1left2": {
+							'pTestVal1': "value2"
+						}
+					},
+					'pTestVal': "value2"
+				}
+			};
+			testApp.hideUrlHash = false;
+			testApp.showOrHideViews('hc1leftParent,hc1left2', params);
+			return displayDeferred.then(function () {
+				var hc1left2content = document.getElementById("hc1leftParent_hc1left2");
+				//var hc1left2View = viewUtils.getViewFromViewId(testApp, "hc1leftParent_hc1left2");
+				//var hc1leftParentView = viewUtils.getViewFromViewId(testApp, "hc1leftParent");
+				checkNodeVisibile(hc1left2content);
+				checkActivateCallCount(hc1left2View, 3, true);
+				assert.deepEqual(hc1left2View.viewData.pTestVal, "value2",
+					" hc1left2View.viewData.pTestVal should equal value2");
+				assert.deepEqual(hc1leftParentView.viewData.pTestVal2, "parentVal2",
+					" hc1leftParentView.viewData.pTestVal2 should equal parentVal2");
+			}).then(function () {
+				var currentHash = window.location.hash;
+				var t2 = "#hc1header1+hc1centerParent+hc1center3+hc1footer1+hc1leftParent,hc1left2";
+				assert.deepEqual(currentHash, t2,
+					" currentHash should be #hc1header1+hc1centerParent+hc1center3+hc1footer1+hc1leftParent,hc1left2");
+			});
+		},
+		// Currently showing #hc1header1+hc1centerParent+hc1center3+hc1footer1+hc1leftParent,hc1left2" test
+		// showOrHideViews('leftParent,left1'
+		"show hc1left1 with testApp.showOrHideViews('hc1leftParent,hc1left1' with viewData)": function () {
+			this.timeout = 10000;
+			var displayDeferred = new Deferred();
+			var params = {
+				displayDeferred: displayDeferred,
+				"viewData": {
+					"views": {
+						"hc1leftParent": {
+							'pTestVal1': "parentVal1"
+						},
+						"hc1leftParent,hc1left1": {
+							'pTestVal1': "value1"
+						}
+					},
+					'pTestVal': "value1"
+				}
+			};
+			testApp.showOrHideViews('hc1leftParent,hc1left1', params);
+			return displayDeferred.then(function () {
+				var hc1left1content = document.getElementById("hc1leftParent_hc1left1");
+				var hc1left1View = viewUtils.getViewFromViewId(testApp, "hc1leftParent_hc1left1");
+				var hc1leftParentView = viewUtils.getViewFromViewId(testApp, "hc1leftParent");
+				checkNodeVisibile(hc1left1content);
+				checkActivateCallCount(hc1left1View, 4, true);
+				assert.deepEqual(hc1left1View.viewData.pTestVal, "value1",
+					" hc1left1View.viewData.pTestVal should equal value1");
+				assert.deepEqual(hc1leftParentView.viewData.pTestVal1, "parentVal1",
+					" hc1leftParentView.viewData.pTestVal1 should equal parentVal1");
+			}).then(function () {
+				var currentHash = window.location.hash;
+				assert.deepEqual(currentHash,
+					"#hc1header1+hc1centerParent+hc1center3+hc1footer1+hc1leftParent,hc1left1",
+					" currentHash should be #hc1header1+hc1centerParent+hc1center3+hc1footer1+hc1leftParent,hc1left1");
+			});
+		},
+		// Currently showing #hc1header1+hc1centerParent+hc1center3+hc1footer1+hc1leftParent,hc1left1" test
+		// history.back()
+		"test history.back() to get back to hc1leftParent,hc1left2 with viewData)": function () {
+			this.timeout = 10000;
+			var displayDeferred = new Deferred();
+			setupOnOnce(displayDeferred);
+			history.back();
+			return displayDeferred.then(function () {
+				var hc1left2content = document.getElementById("hc1leftParent_hc1left2");
+				//var hc1left2View = viewUtils.getViewFromViewId(testApp, "hc1leftParent_hc1left2");
+				//var hc1leftParentView = viewUtils.getViewFromViewId(testApp, "hc1leftParent");
+				checkNodeVisibile(hc1left2content);
+				checkActivateCallCount(hc1left2View, 4, true);
+				assert.deepEqual(hc1left2View.viewData.pTestVal, "value2",
+					" hc1left2View.viewData.pTestVal should equal value2");
+				assert.deepEqual(hc1leftParentView.viewData.pTestVal2, "parentVal2",
+					" hc1leftParentView.viewData.pTestVal2 should equal parentVal2");
+			}).then(function () {
+				var currentHash = window.location.hash;
+				var t2 = "#hc1header1+hc1centerParent+hc1center3+hc1footer1+hc1leftParent,hc1left2";
+				assert.deepEqual(currentHash, t2,
+					" currentHash should be #hc1header1+hc1centerParent+hc1center3+hc1footer1+hc1leftParent,hc1left2");
+			});
+		},
+		// Currently showing #hc1header1+hc1centerParent+hc1center3+hc1footer1+hc1leftParent,hc1left1" test
+		// history.forward()
+		"test history.forward() to get back to hc1leftParent,hc1left1 with viewData)": function () {
+			this.timeout = 10000;
+			var displayDeferred = new Deferred();
+			setupOnOnce(displayDeferred);
+			history.forward();
+			return displayDeferred.then(function () {
+				var hc1left1content = document.getElementById("hc1leftParent_hc1left1");
+				var hc1left1View = viewUtils.getViewFromViewId(testApp, "hc1leftParent_hc1left1");
+				var hc1leftParentView = viewUtils.getViewFromViewId(testApp, "hc1leftParent");
+				checkNodeVisibile(hc1left1content);
+				checkActivateCallCount(hc1left1View, 5, true);
+				assert.deepEqual(hc1left1View.viewData.pTestVal, "value1",
+					" hc1left1View.viewData.pTestVal should equal value1");
+				assert.deepEqual(hc1leftParentView.viewData.pTestVal1, "parentVal1",
+					" hc1leftParentView.viewData.pTestVal1 should equal parentVal1");
+			}).then(function () {
+				var currentHash = window.location.hash;
+				assert.deepEqual(currentHash,
+					"#hc1header1+hc1centerParent+hc1center3+hc1footer1+hc1leftParent,hc1left1",
+					" currentHash should be #hc1header1+hc1centerParent+hc1center3+hc1footer1+hc1leftParent,hc1left1");
+			});
+		},
+		// Currently showing #hc1header1+hc1centerParent+hc1center3+hc1footer1+hc1leftParent,hc1left1" test
+		// showOrHideViews('leftParent,left2' with viewData
+		"show hc1left2 with testApp.showOrHideViews('hc1leftParent,hc1left2' hash set)": function () {
+			this.timeout = 10000;
+			var displayDeferred = new Deferred();
+			var params = {
+				hash: "testHash1",
+				displayDeferred: displayDeferred
+			};
+			testApp.showOrHideViews('hc1leftParent,hc1left2', params);
+			return displayDeferred.then(function () {
+				var hc1left2content = document.getElementById("hc1leftParent_hc1left2");
+				//var hc1left2View = viewUtils.getViewFromViewId(testApp, "hc1leftParent_hc1left2");
+				checkNodeVisibile(hc1left2content);
+				checkActivateCallCount(hc1left2View, 5, true);
+			}).then(function () {
+				var currentHash = window.location.hash;
+				assert.deepEqual(currentHash, "#testHash1", " currentHash should be #testHash1");
+			});
+		},
+		// Currently showing #hc1header1+hc1centerParent+hc1center3+hc1footer1+hc1leftParent,hc1left2" test
+		// showOrHideViews('leftParent,left1'
+		"show hc1left1 with testApp.showOrHideViews('hc1leftParent,hc1left1' with hash set)": function () {
+			this.timeout = 10000;
+			var displayDeferred = new Deferred();
+			var params = {
+				hash: "testHash2",
+				displayDeferred: displayDeferred,
+				"viewParams": {
+					'pTestVal': "value2"
+				}
+			};
+			testApp.showOrHideViews('hc1leftParent,hc1left1', params);
+			return displayDeferred.then(function () {
+				var hc1left1content = document.getElementById("hc1leftParent_hc1left1");
+				var hc1left1View = viewUtils.getViewFromViewId(testApp, "hc1leftParent_hc1left1");
+				checkNodeVisibile(hc1left1content);
+				checkActivateCallCount(hc1left1View, 6, true);
+				assert.deepEqual(hc1left1View.viewParams.pTestVal, "value2",
+					" hc1left1View.viewParams.pTestVal should equal value2");
+			}).then(function () {
+				var currentHash = window.location.hash;
+				assert.deepEqual(currentHash, "#testHash2&pTestVal=value2",
+					" currentHash should be #testHash2&pTestVal=value2");
+			});
+		},
+		// Currently showing #hc1header1+hc1centerParent+hc1center3+hc1footer1+hc1leftParent,hc1left1" test
+		// history.back()
+		"test history.back() to get back to hc1leftParent,hc1left2 with hash set)": function () {
+			this.timeout = 10000;
+			var displayDeferred = new Deferred();
+			setupOnOnce(displayDeferred);
+			history.back();
+			return displayDeferred.then(function () {
+				var hc1left2content = document.getElementById("hc1leftParent_hc1left2");
+				//var hc1left2View = viewUtils.getViewFromViewId(testApp, "hc1leftParent_hc1left2");
+				checkNodeVisibile(hc1left2content);
+				checkActivateCallCount(hc1left2View, 6, true);
+			}).then(function () {
+				var currentHash = window.location.hash;
+				assert.deepEqual(currentHash, "#testHash1", " currentHash should be #testHash1");
+			});
+		},
+		// Currently showing #hc1header1+hc1centerParent+hc1center3+hc1footer1+hc1leftParent,hc1left1" test
+		// history.forward()
+		"test history.forward() to get back to hc1leftParent,hc1left1 with hash set)": function () {
+			this.timeout = 10000;
+			var displayDeferred = new Deferred();
+			setupOnOnce(displayDeferred);
+			history.forward();
+			return displayDeferred.then(function () {
+				var hc1left1content = document.getElementById("hc1leftParent_hc1left1");
+				var hc1left1View = viewUtils.getViewFromViewId(testApp, "hc1leftParent_hc1left1");
+				checkNodeVisibile(hc1left1content);
+				checkActivateCallCount(hc1left1View, 7, true);
+				assert.deepEqual(hc1left1View.viewParams.pTestVal, "value2",
+					" hc1left1View.viewParams.pTestVal should equal value2");
+			}).then(function () {
+				var currentHash = window.location.hash;
+				assert.deepEqual(currentHash, "#testHash2&pTestVal=value2",
+					" currentHash should be #testHash2&pTestVal=value2");
+			});
+		},
+
+		teardown: function () {
+			// call unloadApp to cleanup and end the test
+			historyControllerContainer1.parentNode.removeChild(
+				historyControllerContainer1);
+			testApp.unloadApp();
+		}
+	};
+
+	registerSuite(historyControllerSuite1);
+
+	function setupOnOnce(displayDeferred) {
+		on.once(document, "dapp-finished-transition", function () {
+			displayDeferred.resolve();
+		});
+	}
+
+	function checkNodeVisibile(target) {
+		assert.isTrue(target.style.display !== "none");
+	}
+
+	function checkActivateCallCount(view, count, skipActiveCheck) {
+		if (view) {
+			assert.deepEqual(view._beforeActivateCallCount, count,
+				view.id + " _beforeActivateCallCount should be " + count);
+			assert.deepEqual(view._afterActivateCallCount, count,
+				view.id + " _afterActivateCallCount should be " + count);
+
+			//also test for view._active being set correctly to true
+			if (!skipActiveCheck) {
+				assert.isTrue(view._active, "view_active should be true for " + view.id);
+			}
+		}
+	}
+
+	function checkDeactivateCallCount(view, count, skipActiveCheck) {
+		if (view) {
+			assert.deepEqual(view._beforeDeactivateCallCount, count,
+				view.id + " _beforeDeactivateCallCount should be " + count);
+			assert.deepEqual(view._afterDeactivateCallCount, count,
+				view.id + " _afterDeactivateCallCount should be " + count);
+
+			//also test for view._active being set correctly to false
+			if (!skipActiveCheck) {
+				assert.isFalse(view._active, "view_active should be false for " + view.id);
+			}
+		}
+	}
+
+	// strip out single line comments from the json config
+	function stripComments(jsonData) {
+		jsonData = jsonData.replace(/\/\*.*?\*\//g, "");
+		jsonData = jsonData.replace(/\/\/.*/g, "");
+		return jsonData;
+	}
+
+});

--- a/tests/unit/historyController/app1.json
+++ b/tests/unit/historyController/app1.json
@@ -1,0 +1,95 @@
+{
+	"id": "historyControllerApp1",
+	"name": "historyControllerApp1",
+	"loaderConfig": {
+		"paths": {
+			"historyControllerApp1": "./dapp/tests/unit/historyController"
+		}
+	},
+	"modules": [
+	],
+
+	"controllers": [
+		"dapp/controllers/delite/Init",
+		"dapp/controllers/Logger",
+		"dapp/controllers/delite/Load",
+		"dapp/controllers/delite/Transition",
+		"dapp/controllers/History"
+	],
+
+	"dependencies": [
+		"deliteful/LinearLayout",
+		"deliteful/ViewStack",
+		"deliteful/SidePane"
+	],
+
+	"appLogging": {
+		"logAll": 0
+	},
+
+	"parseOnLoad": true,
+
+	"alwaysUseDefaultView" : true, // ignore any url hash when starting the app
+	"defaultView": "hc1header1+hc1centerParent+hc1center1+hc1right1+hc1footer1",
+	"views": {
+		"hc1header1": {
+			"parentSelector": "#hc1headerViewStack",
+			"controller": "historyControllerApp1/headerController1.js",
+			"template": "historyControllerApp1/headerTemplate1.html"
+		},
+		"hc1leftParent": {
+			"parentSelector": "#hc1leftPane",
+			"controller": "historyControllerApp1/parentController1.js",
+			"template": "historyControllerApp1/leftSubParentTemplate.html",
+			"defaultView": "left1",
+			"views": {
+				"hc1left1": {
+					"parentSelector": "#hc1leftViewStack",
+					"controller": "historyControllerApp1/leftController1.js",
+					"template": "historyControllerApp1/leftTemplate1.html"
+				},
+				"hc1left2": {
+					"parentSelector": "#hc1leftViewStack",
+					"controller": "historyControllerApp1/leftController1.js",
+					"template": "historyControllerApp1/leftTemplate1.html"
+				}
+			}
+		},
+		"hc1centerParent": {
+			"loadViewsInOrder": true,
+			"parentSelector": "#hc1centerLinearLayout",
+			"controller": "historyControllerApp1/parentController1.js",
+			"template": "historyControllerApp1/subParentTemplate.html"
+		},
+		"hc1center1": {
+			"parentSelector": "#hc1centerViewStack",
+			"controller": "historyControllerApp1/centerController1.js",
+			"template": "historyControllerApp1/centerTemplate1.html"
+		},
+		"hc1center2": {
+			"parentSelector": "#hc1centerViewStack",
+			"controller": "historyControllerApp1/centerController1.js",
+			"template": "historyControllerApp1/centerTemplate1.html"
+		},
+		"hc1center3": {
+			"parentSelector": "#hc1centerViewStack",
+			"controller": "historyControllerApp1/centerController1.js",
+			"template": "historyControllerApp1/centerTemplate1.html"
+		},
+		"hc1right1": {
+			"parentSelector": "#hc1rightPane",
+			"controller": "historyControllerApp1/rightController1.js",
+			"template": "historyControllerApp1/rightTemplate1.html"
+		},
+		"hc1right2": {
+			"parentSelector": "#hc1rightPane",
+			"controller": "historyControllerApp1/rightController1.js",
+			"template": "historyControllerApp1/rightTemplate1.html"
+		},
+		"hc1footer1": {
+			"parentSelector": "#hc1footerViewStack",
+			"controller": "historyControllerApp1/footerController1.js",
+			"template": "historyControllerApp1/footerTemplate1.html"
+		}
+	}
+}

--- a/tests/unit/historyController/centerController1.js
+++ b/tests/unit/historyController/centerController1.js
@@ -1,0 +1,43 @@
+define([], function () {
+	return {
+		name: "",
+		_beforeActivateCallCount: 0,
+		_beforeDeactivateCallCount: 0,
+		_afterActivateCallCount: 0,
+		_afterDeactivateCallCount: 0,
+		init: function () {
+			this.domNode.name = this.id;
+		},
+		beforeActivate: function (previousView, viewData) {
+			this.app.log("app-view:", "beforeActivate called for [" + this.viewName + "] with previousView.id =[" +
+				(previousView ? previousView.id : "") + "] with viewData=", viewData);
+			this._beforeActivateCallCount++;
+			if (this.id === "center1") {
+				this.domNode.style.backgroundColor = "cyan";
+			} else {
+				this.domNode.style.backgroundColor = "green";
+			}
+		},
+		beforeDeactivate: function (nextView) {
+			this.app.log("app-view:", "beforeDeactivate called for [" + this.viewName + "] with previousView.id =[" +
+				(nextView ? nextView.id : "") + "]");
+			this._beforeDeactivateCallCount++;
+		},
+		afterActivate: function (previousView, viewData) {
+			this.app.log("app-view:", "afterActivate called for [" + this.viewName + "] with previousView.id =[" +
+				(previousView ? previousView.id : "") + "] with viewData=", viewData);
+			this._afterActivateCallCount++;
+			this.app.emit("afterActivateCalled", {
+				view: this
+			});
+		},
+		afterDeactivate: function (nextView) {
+			this.app.log("app-view:", "afterDeactivate called for [" + this.viewName + "] with previousView.id =[" +
+				(nextView ? nextView.id : "") + "]");
+			this._afterDeactivateCallCount++;
+		},
+		destroy: function () {
+			this.app.log("app-view:", " in [" + this.viewName + "] destroy called for [" + this.id + "]");
+		}
+	};
+});

--- a/tests/unit/historyController/centerTemplate1.html
+++ b/tests/unit/historyController/centerTemplate1.html
@@ -1,0 +1,17 @@
+<template class="fill view mblView" style="width: 100%; height: 100%;">Test View {{name}}
+	<div>Test View {{name}}  Center
+		<ul>
+			<li on-click="sidePane1App1.showOrHideViews('leftParent,left1',{transition:'slide'})">DisplayView Show left1 >>>>></li>
+			<li on-click="sidePane1App1.showOrHideViews('-leftParent-leftParent,left1',{transition:'none'})">DisplayView Hide left1 >>>>></li>
+			<li on-click="sidePane1App1.showOrHideViews('leftParent,left2',{transition:'slide'})">DisplayView Show left2 >>>>></li>
+			<li on-click="sidePane1App1.showOrHideViews('-leftParent-leftParent,left2')">DisplayView Hide left2 >>>>></li>
+			<li on-click="sidePane1App1.showOrHideViews('right1')">DisplayView Show right1 >>>>></li>
+			<li on-click="sidePane1App1.showOrHideViews('-right1')">DisplayView Hide right1 >>>>></li>
+			<li on-click="sidePane1App1.showOrHideViews('right2')">DisplayView Show right2 >>>>></li>
+			<li on-click="sidePane1App1.showOrHideViews('-right2')">DisplayView Hide right2 >>>>></li>
+			<li on-click="sidePane1App1.showOrHideViews('right1-centerParent')">DisplayView Hide centerParent show right1 >>>>></li>
+			<li on-click="hc1rightPane.show('right2')">rightPane.show right2 >>>>></li>
+			<li on-click="hc1rightPane.hide('right2')">rightPane.hide right2 >>>>></li>
+		</ul>
+	</div>
+</template>

--- a/tests/unit/historyController/footerController1.js
+++ b/tests/unit/historyController/footerController1.js
@@ -1,0 +1,38 @@
+define([], function () {
+	return {
+		name: "",
+		_beforeActivateCallCount: 0,
+		_beforeDeactivateCallCount: 0,
+		_afterActivateCallCount: 0,
+		_afterDeactivateCallCount: 0,
+		init: function () {
+			this.domNode.name = this.id;
+		},
+		beforeActivate: function (previousView, viewData) {
+			this.app.log("app-view:", "beforeActivate called for [" + this.viewName + "] with previousView.id =[" +
+				(previousView ? previousView.id : "") + "] with viewData=", viewData);
+			this._beforeActivateCallCount++;
+		},
+		beforeDeactivate: function (nextView) {
+			this.app.log("app-view:", "beforeDeactivate called for [" + this.viewName + "] with previousView.id =[" +
+				(nextView ? nextView.id : "") + "]");
+			this._beforeDeactivateCallCount++;
+		},
+		afterActivate: function (previousView, viewData) {
+			this.app.log("app-view:", "afterActivate called for [" + this.viewName + "] with previousView.id =[" +
+				(previousView ? previousView.id : "") + "] with viewData=", viewData);
+			this._afterActivateCallCount++;
+			this.app.emit("afterActivateCalled", {
+				view: this
+			});
+		},
+		afterDeactivate: function (nextView) {
+			this.app.log("app-view:", "afterDeactivate called for [" + this.viewName + "] with previousView.id =[" +
+				(nextView ? nextView.id : "") + "]");
+			this._afterDeactivateCallCount++;
+		},
+		destroy: function () {
+			this.app.log("app-view:", " in [" + this.viewName + "] destroy called for [" + this.id + "]");
+		}
+	};
+});

--- a/tests/unit/historyController/footerTemplate1.html
+++ b/tests/unit/historyController/footerTemplate1.html
@@ -1,0 +1,3 @@
+<template class="view mblView" style="width: 100%; height: 100%; background-color: pink; position: absolute">Test View {{name}}
+	<div>Test View {{name}}   Footer1</div>
+</template>

--- a/tests/unit/historyController/headerController1.js
+++ b/tests/unit/historyController/headerController1.js
@@ -1,0 +1,38 @@
+define([], function () {
+	return {
+		name: "",
+		_beforeActivateCallCount: 0,
+		_beforeDeactivateCallCount: 0,
+		_afterActivateCallCount: 0,
+		_afterDeactivateCallCount: 0,
+		init: function () {
+			this.domNode.name = this.id;
+		},
+		beforeActivate: function (previousView, viewData) {
+			this.app.log("app-view:", "beforeActivate called for [" + this.viewName + "] with previousView.id =[" +
+				(previousView ? previousView.id : "") + "] with viewData=", viewData);
+			this._beforeActivateCallCount++;
+		},
+		beforeDeactivate: function (nextView) {
+			this.app.log("app-view:", "beforeDeactivate called for [" + this.viewName + "] with previousView.id =[" +
+				(nextView ? nextView.id : "") + "]");
+			this._beforeDeactivateCallCount++;
+		},
+		afterActivate: function (previousView, viewData) {
+			this.app.log("app-view:", "afterActivate called for [" + this.viewName + "] with previousView.id =[" +
+				(previousView ? previousView.id : "") + "] with viewData=", viewData);
+			this._afterActivateCallCount++;
+			this.app.emit("afterActivateCalled", {
+				view: this
+			});
+		},
+		afterDeactivate: function (nextView) {
+			this.app.log("app-view:", "afterDeactivate called for [" + this.viewName + "] with previousView.id =[" +
+				(nextView ? nextView.id : "") + "]");
+			this._afterDeactivateCallCount++;
+		},
+		destroy: function () {
+			this.app.log("app-view:", " in [" + this.viewName + "] destroy called for [" + this.id + "]");
+		}
+	};
+});

--- a/tests/unit/historyController/headerTemplate1.html
+++ b/tests/unit/historyController/headerTemplate1.html
@@ -1,0 +1,3 @@
+<template class="view mblView fill" style="width: 100%; height: 100%; background-color: blue; position: absolute">Test View {{name}}
+	<div>Test View {{name}}   HEADER1</div>
+</template>

--- a/tests/unit/historyController/leftController1.js
+++ b/tests/unit/historyController/leftController1.js
@@ -1,0 +1,44 @@
+define([], function () {
+	return {
+		name: "",
+		_beforeActivateCallCount: 0,
+		_beforeDeactivateCallCount: 0,
+		_afterActivateCallCount: 0,
+		_afterDeactivateCallCount: 0,
+		init: function () {
+			this.domNode.name = this.id;
+		},
+		beforeActivate: function (previousView, viewData) {
+			this.app.log("app-view:", "beforeActivate called for [" + this.viewName + "] with previousView.id =[" +
+				(previousView ? previousView.id : "") + "] with viewData=", viewData);
+			this._beforeActivateCallCount++;
+			this.viewData = viewData;
+			if (this.id === "right1") {
+				this.domNode.style.backgroundColor = "darkgoldenrod";
+			} else {
+				this.domNode.style.backgroundColor = "orange";
+			}
+		},
+		beforeDeactivate: function (nextView) {
+			this.app.log("app-view:", "beforeDeactivate called for [" + this.viewName + "] with previousView.id =[" +
+				(nextView ? nextView.id : "") + "]");
+			this._beforeDeactivateCallCount++;
+		},
+		afterActivate: function (previousView, viewData) {
+			this.app.log("app-view:", "afterActivate called for [" + this.viewName + "] with previousView.id =[" +
+				(previousView ? previousView.id : "") + "] with viewData=", viewData);
+			this._afterActivateCallCount++;
+			this.app.emit("afterActivateCalled", {
+				view: this
+			});
+		},
+		afterDeactivate: function (nextView) {
+			this.app.log("app-view:", "afterDeactivate called for [" + this.viewName + "] with previousView.id =[" +
+				(nextView ? nextView.id : "") + "]");
+			this._afterDeactivateCallCount++;
+		},
+		destroy: function () {
+			this.app.log("app-view:", " in [" + this.viewName + "] destroy called for [" + this.id + "]");
+		}
+	};
+});

--- a/tests/unit/historyController/leftSubParentTemplate.html
+++ b/tests/unit/historyController/leftSubParentTemplate.html
@@ -1,0 +1,5 @@
+<template class="fill" style="background-color: cadetblue">
+	<!--(note initial size was not be set right, had to set ; height: 100% above) -->
+	<d-view-stack id="hc1leftViewStack" class="fill" style="width: 100%; height: 100%; background-color: lightcyan">
+	</d-view-stack>
+</template>

--- a/tests/unit/historyController/leftTemplate1.html
+++ b/tests/unit/historyController/leftTemplate1.html
@@ -1,0 +1,4 @@
+<template class="view mblView fill">Test View {{name}}
+	<div>Test View {{name}}
+	</div>
+</template>

--- a/tests/unit/historyController/parentController1.js
+++ b/tests/unit/historyController/parentController1.js
@@ -1,0 +1,39 @@
+define([], function () {
+	return {
+		name: "",
+		_beforeActivateCallCount: 0,
+		_beforeDeactivateCallCount: 0,
+		_afterActivateCallCount: 0,
+		_afterDeactivateCallCount: 0,
+		init: function () {
+			this.domNode.name = this.id;
+		},
+		beforeActivate: function (previousView, viewData) {
+			this.app.log("app-view:", "beforeActivate called for [" + this.viewName + "] with previousView.id =[" +
+				(previousView ? previousView.id : "") + "] with viewData=", viewData);
+			this.viewData = viewData;
+			this._beforeActivateCallCount++;
+		},
+		beforeDeactivate: function (nextView) {
+			this.app.log("app-view:", "beforeDeactivate called for [" + this.viewName + "] with previousView.id =[" +
+				(nextView ? nextView.id : "") + "]");
+			this._beforeDeactivateCallCount++;
+		},
+		afterActivate: function (previousView, viewData) {
+			this.app.log("app-view:", "afterActivate called for [" + this.viewName + "] with previousView.id =[" +
+				(previousView ? previousView.id : "") + "] with viewData=", viewData);
+			this._afterActivateCallCount++;
+			this.app.emit("afterActivateCalled", {
+				view: this
+			}); // do not do this for the parentView
+		},
+		afterDeactivate: function (nextView) {
+			this.app.log("app-view:", "afterDeactivate called for [" + this.viewName + "] with previousView.id =[" +
+				(nextView ? nextView.id : "") + "]");
+			this._afterDeactivateCallCount++;
+		},
+		destroy: function () {
+			this.app.log("app-view:", " in [" + this.viewName + "] destroy called for [" + this.id + "]");
+		}
+	};
+});

--- a/tests/unit/historyController/parentTemplate.html
+++ b/tests/unit/historyController/parentTemplate.html
@@ -1,0 +1,5 @@
+<template>
+	<!--(note initial size was not be set right, had to set ; height: 100% above) -->
+	<d-linear-layout style="width:100%; height: 100%" direction="vertical">
+	</d-linear-layout>
+</template>

--- a/tests/unit/historyController/rightController1.js
+++ b/tests/unit/historyController/rightController1.js
@@ -1,0 +1,43 @@
+define([], function () {
+	return {
+		name: "",
+		_beforeActivateCallCount: 0,
+		_beforeDeactivateCallCount: 0,
+		_afterActivateCallCount: 0,
+		_afterDeactivateCallCount: 0,
+		init: function () {
+			this.domNode.name = this.id;
+		},
+		beforeActivate: function (previousView, viewData) {
+			this.app.log("app-view:", "beforeActivate called for [" + this.viewName + "] with previousView.id =[" +
+				(previousView ? previousView.id : "") + "] with viewData=", viewData);
+			this._beforeActivateCallCount++;
+			if (this.id === "right1") {
+				this.domNode.style.backgroundColor = "darkgoldenrod";
+			} else {
+				this.domNode.style.backgroundColor = "orange";
+			}
+		},
+		beforeDeactivate: function (nextView) {
+			this.app.log("app-view:", "beforeDeactivate called for [" + this.viewName + "] with previousView.id =[" +
+				(nextView ? nextView.id : "") + "]");
+			this._beforeDeactivateCallCount++;
+		},
+		afterActivate: function (previousView, viewData) {
+			this.app.log("app-view:", "afterActivate called for [" + this.viewName + "] with previousView.id =[" +
+				(previousView ? previousView.id : "") + "] with viewData=", viewData);
+			this._afterActivateCallCount++;
+			this.app.emit("afterActivateCalled", {
+				view: this
+			});
+		},
+		afterDeactivate: function (nextView) {
+			this.app.log("app-view:", "afterDeactivate called for [" + this.viewName + "] with previousView.id =[" +
+				(nextView ? nextView.id : "") + "]");
+			this._afterDeactivateCallCount++;
+		},
+		destroy: function () {
+			this.app.log("app-view:", " in [" + this.viewName + "] destroy called for [" + this.id + "]");
+		}
+	};
+});

--- a/tests/unit/historyController/rightTemplate1.html
+++ b/tests/unit/historyController/rightTemplate1.html
@@ -1,0 +1,4 @@
+<template class="view mblView fill">Test View {{name}}
+	<div>Test View {{name}}
+	</div>
+</template>

--- a/tests/unit/historyController/subParentTemplate.html
+++ b/tests/unit/historyController/subParentTemplate.html
@@ -1,0 +1,5 @@
+<template class="fill" style="background-color: cadetblue">
+	<!--(note initial size was not be set right, had to set ; height: 100% above) -->
+	<d-view-stack id="hc1centerViewStack" class="fill" style="width: 100%; height: 100%; background-color: green">
+	</d-view-stack>
+</template>

--- a/tests/unit/multipleAndNestedViewsActivateCalls/app1.json
+++ b/tests/unit/multipleAndNestedViewsActivateCalls/app1.json
@@ -13,7 +13,8 @@
 		"dapp/controllers/delite/Init",
 		"dapp/controllers/Logger",
 		"dapp/controllers/delite/Load",
-		"dapp/controllers/delite/Transition"
+		"dapp/controllers/delite/Transition",
+		"dapp/controllers/History"
 	],
 
 	"dependencies": [
@@ -27,6 +28,7 @@
 
 	"parseOnLoad": true,
 
+	"alwaysUseDefaultView" : true, // ignore any url hash when starting the app
 	"defaultView": "H1+content,P1",
 	"views": {
 		"H1": {

--- a/tests/unit/multipleAndNestedViewsActivateCalls/app1Constraints.json
+++ b/tests/unit/multipleAndNestedViewsActivateCalls/app1Constraints.json
@@ -27,6 +27,7 @@
 
 	"parseOnLoad": true,
 
+	"alwaysUseDefaultView" : true, // ignore any url hash when starting the app
 	"defaultView": "H1Cons+contentCons,P1",
 	"views": {
 		"H1Cons": {

--- a/tests/unit/nestedViewsActivateCalls/app1.json
+++ b/tests/unit/nestedViewsActivateCalls/app1.json
@@ -13,7 +13,8 @@
 		"dapp/controllers/delite/Init",
 		"dapp/controllers/Logger",
 		"dapp/controllers/delite/Load",
-		"dapp/controllers/delite/Transition"
+		"dapp/controllers/delite/Transition",
+		"dapp/controllers/History"
 	],
 
 	"dependencies": [
@@ -29,6 +30,7 @@
 
 	"parseOnLoad": true,
 
+	"alwaysUseDefaultView" : true, // ignore any url hash when starting the app
 	"defaultView": "P1",
 	"views": {
 		"P1": {

--- a/tests/unit/nlsLabels/app.json
+++ b/tests/unit/nlsLabels/app.json
@@ -30,7 +30,7 @@
 	"parseOnLoad": true,
 	"nls": "nlsLabelsApp/nls/app",
 
-	//TODO: There is a problem with using duplicate view names across tests, getting duplicate view error!!!
+	"alwaysUseDefaultView" : true, // ignore any url hash when starting the app
 	"defaultView": "nlsLabelsAppHome1",
 	"views": {
 		"nlsLabelsAppHome1": {

--- a/tests/unit/sidePaneViewsActivateCalls/app1.json
+++ b/tests/unit/sidePaneViewsActivateCalls/app1.json
@@ -13,7 +13,8 @@
 		"dapp/controllers/delite/Init",
 		"dapp/controllers/Logger",
 		"dapp/controllers/delite/Load",
-		"dapp/controllers/delite/Transition"
+		"dapp/controllers/delite/Transition",
+		"dapp/controllers/History"
 	],
 
 	"dependencies": [
@@ -28,6 +29,7 @@
 
 	"parseOnLoad": true,
 
+	"alwaysUseDefaultView" : true, // ignore any url hash when starting the app
 	"defaultView": "sp1header1+sp1centerParent+sp1center1+sp1right1+sp1footer1",
 	"views": {
 		"sp1header1": {

--- a/tests/unit/transitionVisibility/app.json
+++ b/tests/unit/transitionVisibility/app.json
@@ -13,7 +13,8 @@
 		"dapp/controllers/delite/Init",
 		"dapp/controllers/Logger",
 		"dapp/controllers/delite/Load",
-		"dapp/controllers/delite/Transition"
+		"dapp/controllers/delite/Transition",
+		"dapp/controllers/History"
 	],
 
 	"dependencies": [
@@ -28,6 +29,7 @@
 		"logAll": 0
 	},
 
+	"alwaysUseDefaultView" : true, // ignore any url hash when starting the app
 	"defaultView": "transitionVisibilityAppHome1",
 	"views": {
 		"transitionVisibilityAppHome1": {

--- a/tests/unit/viewDataAndParams/app.json
+++ b/tests/unit/viewDataAndParams/app.json
@@ -13,7 +13,8 @@
 		"dapp/controllers/delite/Init",
 		"dapp/controllers/Logger",
 		"dapp/controllers/delite/Load",
-		"dapp/controllers/delite/Transition"
+		"dapp/controllers/delite/Transition",
+		"dapp/controllers/History"
 	],
 
 	"dependencies": [

--- a/tests/unit/viewLayout/app.json
+++ b/tests/unit/viewLayout/app.json
@@ -13,7 +13,8 @@
 		"dapp/controllers/delite/Init",
 		"dapp/controllers/Logger",
 		"dapp/controllers/delite/Load",
-		"dapp/controllers/delite/Transition"
+		"dapp/controllers/delite/Transition",
+		"dapp/controllers/History"
 	],
 
 	"dependencies": [
@@ -26,6 +27,7 @@
 		"logAll": 0
 	},
 
+	"alwaysUseDefaultView" : true, // ignore any url hash when starting the app
 	"defaultView": "viewLayoutAppHome1+viewLayoutAppHome2+viewLayoutAppHome3NoController",
 	"views": {
 		"viewLayoutAppHome1": {


### PR DESCRIPTION
Updates to dapp for the History controller support including updates to pass viewParams and viewData with params and data for specific views, support to hide a view on browser back if it was just shown on the current view, and tests for all of the history support, as well as new config options for alwaysUseDefaultView and hideUrlHash

I noticed that I left onclick in one of the history test templates, update it to on-click
