### PR TITLE
More updates to move up to the latest delite, and deliteful, and decor. ...

### DIFF
--- a/View.js
+++ b/View.js
@@ -1,8 +1,8 @@
-define(["require", "dojo/when", "dojo/on", "dcl/dcl", "dojo/Deferred", "delite/Widget", "delite/register",
+define(["require", "dojo/when", "dcl/dcl", "dojo/Deferred", "delite/Widget", "delite/register",
 		"delite/handlebars", "./ViewBase", "./utils/nls"
 	],
-	function (require, when, on, dcl, Deferred, Widget, register, handlebars, ViewBase, nls) {
-		return dcl([ViewBase, Widget], {
+	function (require, when, dcl, Deferred, Widget, register, handlebars, ViewBase, nls) {
+		return dcl([ViewBase], {
 			// summary:
 			//		View class inheriting from ViewBase adding templating & globalization capabilities.
 			constructor: function (viewParams) { // jshint unused:false
@@ -53,11 +53,6 @@ define(["require", "dojo/when", "dojo/on", "dcl/dcl", "dojo/Deferred", "delite/W
 				//		- parentView: parent view
 				//		- children: children views
 				//		- nls: nls definition module identifier
-			},
-
-			// _TemplatedMixin requires a connect method if data-dojo-attach-* are used
-			connect: function (obj, event, method) {
-				return this.own(on(obj, event, method.bind(this)))[0]; // handle
 			},
 
 			_loadTemplate: function () {
@@ -151,7 +146,7 @@ define(["require", "dojo/when", "dojo/on", "dcl/dcl", "dojo/Deferred", "delite/W
 					register(tag, [HTMLElement, Widget], viewParams);
 
 					this.domNode = register.createElement(tag);
-					this.own(this.domNode);
+					//this.own(this.domNode); // had problem extending Widget
 					this.domNode.id = this.id;
 
 					//had to do this for widgets in templates to work

--- a/ViewBase.js
+++ b/ViewBase.js
@@ -1,5 +1,5 @@
-define(["require", "dojo/when", "dojo/on", "dcl/dcl", "dojo/Deferred", "./utils/view"],
-	function (require, when, on, dcl, Deferred, viewUtils) {
+define(["require", "dojo/when", "dcl/dcl", "dojo/Deferred", "./utils/view"],
+	function (require, when, dcl, Deferred, viewUtils) {
 		return dcl(null, {
 			// summary:
 			//		View base class with controller capabilities. Subclass must implement rendering capabilities.

--- a/bower.json
+++ b/bower.json
@@ -1,10 +1,10 @@
 {
 	"name": "dapp",
-	"version": "0.1.0-dev",
+	"version": "0.1.1-dev",
 	"dependencies": {
 		"dcl": "1.1.x",
-		"decor": "0.1.0-dev",
-		"delite": "#master",
+		"decor": "0.2.0-beta",
+		"delite": "0.2.0-beta",
 		"deliteful": "#master",
 		"dojo": ">=1.9.1",
 		"dpointer": ">=0.1.0-dev",

--- a/controllers/delite/Init.js
+++ b/controllers/delite/Init.js
@@ -1,12 +1,32 @@
-define(["require", "dcl/dcl", "dojo/on", "dojo/Deferred", "dojo/_base/lang",
+/** @module dapp/controllers/delite/Init */
+define(["require", "dcl/dcl", "dojo/Deferred",
 		"../../utils/hash", "../../Controller", "dojo/_base/declare"
 	],
-	function (require, dcl, on, Deferred, lang, hash, Controller, declare) {
+	function (require, dcl, Deferred, hash, Controller, declare) {
+		/**
+		 * An Init controller for a dapp application using delite.
+		 *
+		 * @class module:dapp/controllers/delite/Init
+		 * @augments module:dapp/Controller
+		 */
+		/**
+		 * Get a property from a dot-separated string, such as "A.B.C".
+		 */
+		function getObject(name) {
+			try {
+				return name.split(".").reduce(function (context, part) {
+					return context[part];
+				}, this); // "this" is the global object (i.e. window on browsers)
+			} catch (e) {
+				// Return undefined to indicate that object doesn't exist.
+			}
+		}
+
 		return dcl(Controller, {
 			constructor: function () {
 				this.events = {
-					"dapp-init": this._initHandler,
-					"dapp-setup-view-stores": this._createDataStore
+					"dapp-init": this._initHandler.bind(this),
+					"dapp-setup-view-stores": this._createDataStore.bind(this)
 				};
 			},
 			_initHandler: function () {
@@ -47,7 +67,7 @@ define(["require", "dcl/dcl", "dojo/on", "dojo/Deferred", "dojo/_base/lang",
 								//cannot assign object literal or reference to data property
 								//because json.ref will generate __parent to point to its parent
 								//and will cause infinitive loop when creating StatefulModel.
-								config.data = lang.getObject(config.data);
+								config.data = getObject(config.data);
 							}
 							if (appOrView.stores[item].observable) {
 								var observableCtor;
@@ -111,7 +131,7 @@ define(["require", "dcl/dcl", "dojo/on", "dojo/Deferred", "dojo/_base/lang",
 				// let's display default view
 				var initialView = this.app.alwaysUseDefaultView ? this.app.defaultView : this.app._startView;
 				var initialParams = this.app.alwaysUseDefaultView ? this.app.defaultParams : this.app._startParams;
-				on.emit(document, "dapp-display", {
+				this.app.emit("dapp-display", {
 					// TODO is that really defaultView a good name? Shouldn't it be defaultTarget or defaultView_s_?
 					dest: initialView,
 					viewParams: initialParams,
@@ -121,7 +141,7 @@ define(["require", "dcl/dcl", "dojo/on", "dojo/Deferred", "dojo/_base/lang",
 				});
 				if (this.app) {
 					displayDeferred.then(function () {
-						this.app.status = this.app.lifecycle.STARTED;
+						this.app.setStatus(this.app.STARTED);
 						this.app.appStartedDef.resolve(this.app); // resolve the deferred from new Application
 					}.bind(this));
 				}

--- a/controllers/delite/Transition.js
+++ b/controllers/delite/Transition.js
@@ -1,5 +1,5 @@
-define(["dcl/dcl", "dojo/when", "dojo/Deferred", "dojo/promise/all", "dojo/on", "../../Controller", "../../utils/view"],
-	function (dcl, when, Deferred, all, on, Controller, viewUtils) {
+define(["dcl/dcl", "dojo/when", "dojo/Deferred", "dojo/promise/all", "../../Controller", "../../utils/view"],
+	function (dcl, when, Deferred, all, Controller, viewUtils) {
 
 		// summary:
 		//		A Transition controller to listen for "dapp-display" events and drive the transitions for those
@@ -16,8 +16,8 @@ define(["dcl/dcl", "dojo/when", "dojo/Deferred", "dojo/promise/all", "dojo/on", 
 				// app:
 				//		dapp application instance.
 				this.app = app;
-				this.docEvents = {
-					"dapp-display": this._displayHandler
+				this.events = {
+					"dapp-display": this._displayHandler.bind(this)
 				};
 			},
 
@@ -121,7 +121,7 @@ define(["dcl/dcl", "dojo/when", "dojo/Deferred", "dojo/promise/all", "dojo/on", 
 						//		"viewParams": event.viewParams,
 						//		"transition": event.transition
 						//	};
-						on.emit(document, "dapp-finished-transition", event);
+						self.app.emit("dapp-finished-transition", event);
 						if (event.displayDeferred) {
 							event.displayDeferred.resolve(value);
 						}

--- a/tests/functional/simple1/centerController1.js
+++ b/tests/functional/simple1/centerController1.js
@@ -28,9 +28,6 @@ define([], function () {
 			//console.log("app-view:", "afterActivate called for [" + this.viewName + "] with previousView.id =[" +
 			//	(previousView ? previousView.id : "") + "] with viewData=", viewData);
 			this._afterActivateCallCount++;
-			this.app.emit("afterActivateCalled", {
-				view: this
-			});
 		},
 		afterDeactivate: function ( /*nextView, viewData*/ ) {
 			//console.log("app-view:", "afterDeactivate called for [" + this.viewName + "] with previousView.id =[" +

--- a/tests/functional/simple1/footerController1.js
+++ b/tests/functional/simple1/footerController1.js
@@ -23,9 +23,6 @@ define([], function () {
 			//console.log("app-view:", "afterActivate called for [" + this.viewName + "] with previousView.id =[" +
 			//	(previousView ? previousView.id : "") + "] with viewData=", viewData);
 			this._afterActivateCallCount++;
-			this.app.emit("afterActivateCalled", {
-				view: this
-			});
 		},
 		afterDeactivate: function ( /*nextView, viewData*/ ) {
 			//console.log("app-view:", "afterDeactivate called for [" + this.viewName + "] with previousView.id =[" +

--- a/tests/functional/simple1/headerController1.js
+++ b/tests/functional/simple1/headerController1.js
@@ -23,9 +23,6 @@ define([], function () {
 			//console.log("app-view:", "afterActivate called for [" + this.viewName + "] with previousView.id =[" +
 			//	(previousView ? previousView.id : "") + "] with viewData=", viewData);
 			this._afterActivateCallCount++;
-			this.app.emit("afterActivateCalled", {
-				view: this
-			});
 		},
 		afterDeactivate: function ( /*nextView, viewData*/ ) {
 			//console.log("app-view:", "afterDeactivate called for [" + this.viewName + "] with previousView.id =[" +

--- a/tests/functional/simple1/parentController1.js
+++ b/tests/functional/simple1/parentController1.js
@@ -23,9 +23,6 @@ define([], function () {
 			//console.log("app-view:", "afterActivate called for [" + this.viewName + "] with previousView.id =[" +
 			//	(previousView ? previousView.id : "") + "] with viewData=", viewData);
 			this._afterActivateCallCount++;
-			this.app.emit("afterActivateCalled", {
-				view: this
-			}); // do not do this for the parentView
 		},
 		afterDeactivate: function ( /*nextView, viewData*/ ) {
 			//console.log("app-view:", "afterDeactivate called for [" + this.viewName + "] with previousView.id =[" +

--- a/tests/unit/dstoreMemory/App.js
+++ b/tests/unit/dstoreMemory/App.js
@@ -1,25 +1,25 @@
 // jshint quotmark:false
-require(["dojo/_base/window", "dapp/Application", "dojo/json", "requirejs-text/text!./app.json", "dojo/sniff"],
-	function (win, Application, json, config, has) {
-		win.global.dstoreMemoryApp = {};
-		win.global.dstoreMemoryApp.list1Data = {
+require(["dapp/Application", "dojo/json", "requirejs-text/text!./app.json", "dojo/sniff"],
+	function (Application, json, config, has) {
+		window.dstoreMemoryApp = {};
+		window.dstoreMemoryApp.list1Data = {
 			identifier: "id",
 			'items': []
 		};
 		for (var i = 1; i < 6; i++) {
-			win.global.dstoreMemoryApp.list1Data.items.push({
+			window.dstoreMemoryApp.list1Data.items.push({
 				label: "Selection " + i,
 				id: i
 			});
 		}
 
 
-		win.global.dstoreMemoryApp.list2Data = {
+		window.dstoreMemoryApp.list2Data = {
 			identifier: "id",
 			'items': []
 		};
 		for (i = 6; i < 11; i++) {
-			win.global.dstoreMemoryApp.list2Data.items.push({
+			window.dstoreMemoryApp.list2Data.items.push({
 				label: "Selection " + i,
 				id: i
 			});

--- a/tests/unit/dstoreMemory/Test.js
+++ b/tests/unit/dstoreMemory/Test.js
@@ -2,21 +2,15 @@
 define([
 	"intern!object",
 	"intern/chai!assert",
-	"dojo/_base/window",
 	"dapp/Application",
 	"dojo/json",
-	"dojo/topic",
-	"dojo/on",
-	"dojo/dom-geometry",
-	"dojo/dom-class",
-	"delite/register",
 	"dojo/Deferred",
 	"requirejs-text/text!dapp/tests/unit/dstoreMemory/app.json",
 	"deliteful/LinearLayout",
 	"deliteful/ViewStack",
 	"deliteful/list/List",
 	"dstore/Memory"
-], function (registerSuite, assert, win, Application, json, topic, on, domGeom, domClass, register, Deferred,
+], function (registerSuite, assert, Application, json, Deferred,
 	dstoreMemoryconfig1) {
 	// -------------------------------------------------------------------------------------- //
 	// for dstoreMemorySuite1 transition test
@@ -33,25 +27,25 @@ define([
 		"</d-view-stack>";
 
 
-	win.global.dstoreMemoryApp = {};
-	win.global.dstoreMemoryApp.list1Data = {
+	window.dstoreMemoryApp = {};
+	window.dstoreMemoryApp.list1Data = {
 		identifier: "id",
 		'items': []
 	};
 	for (var i = 1; i < 6; i++) {
-		win.global.dstoreMemoryApp.list1Data.items.push({
+		window.dstoreMemoryApp.list1Data.items.push({
 			label: "Selection " + i,
 			id: i
 		});
 	}
 
 
-	win.global.dstoreMemoryApp.list2Data = {
+	window.dstoreMemoryApp.list2Data = {
 		identifier: "id",
 		'items': []
 	};
 	for (i = 6; i < 11; i++) {
-		win.global.dstoreMemoryApp.list2Data.items.push({
+		window.dstoreMemoryApp.list2Data.items.push({
 			label: "Selection " + i,
 			id: i
 		});
@@ -63,7 +57,6 @@ define([
 			dstoreMemoryContainer1 = document.createElement("div");
 			document.body.appendChild(dstoreMemoryContainer1);
 			dstoreMemoryContainer1.innerHTML = dstoreMemoryHtmlContent1;
-			//	register.parse(dstoreMemoryContainer1); // no need to call parse here config has "parseOnLoad": true
 		},
 		"test initial view": function () {
 			this.timeout = 20000;

--- a/tests/unit/dstoreMemory/viewController.js
+++ b/tests/unit/dstoreMemory/viewController.js
@@ -1,6 +1,6 @@
 // jshint quotmark:false
-define(["dojo/dom", "dojo/on"],
-	function (dom, on) {
+define(["dojo/dom"],
+	function (dom) {
 		return {
 			name: "",
 			lastSelection: "",
@@ -25,7 +25,7 @@ define(["dojo/dom", "dojo/on"],
 				var dstoreMemoryApp = this.app;
 
 				// When the list is clicked, transition to dstoreMemoryAppHome2, pass the label of the selected item.
-				on(this.domNode.ownerDocument.getElementById("list1"), "click",
+				this.domNode.ownerDocument.getElementById("list1").on("click",
 					function ( /*MouseEvent*/ evt) {
 						var label = evt.target.innerHTML || "";
 						var targetView = "dstoreMemoryAppHome2";

--- a/tests/unit/dstoreMemory/viewController2.js
+++ b/tests/unit/dstoreMemory/viewController2.js
@@ -1,6 +1,6 @@
 // jshint quotmark:false
-define(["dojo/dom", "dojo/on"],
-	function (dom, on) {
+define(["dojo/dom"],
+	function (dom) {
 		return {
 			name: "",
 			lastSelection: "",
@@ -22,7 +22,7 @@ define(["dojo/dom", "dojo/on"],
 				list.store = this.loadedStores.list2Store;
 
 				// When the list is clicked, transition to dstoreMemoryAppHome2, pass the label of the selected item.
-				on(this.domNode.ownerDocument.getElementById("list2"), "click",
+				this.domNode.ownerDocument.getElementById("list2").on("click",
 					function ( /*MouseEvent*/ evt) {
 						var label = evt.target.innerHTML || "";
 						var params = {
@@ -50,9 +50,6 @@ define(["dojo/dom", "dojo/on"],
 				//console.log("app-view:", "afterActivate called for [" + this.viewName + "] with previousView.id =[" +
 				//	(previousView ? previousView.id : "") + "] with viewData=", viewData);
 				this._afterActivateCallCount++;
-				//	this.app.emit("afterActivateCalled", {
-				//		view: this
-				//	});
 			},
 			afterDeactivate: function ( /*nextView, viewData*/ ) {
 				//console.log("app-view:", "afterDeactivate called for [" + this.viewName +

--- a/tests/unit/hideView/Test.js
+++ b/tests/unit/hideView/Test.js
@@ -5,16 +5,11 @@ define([
 	"dapp/Application",
 	"dapp/utils/view",
 	"dojo/json",
-	"dojo/topic",
-	"dojo/on",
-	"dojo/dom-geometry",
-	"dojo/dom-class",
-	"delite/register",
 	"dojo/Deferred",
 	"requirejs-text/text!dapp/tests/unit/hideView/app.json",
 	"deliteful/LinearLayout",
 	"deliteful/ViewStack"
-], function (registerSuite, assert, Application, viewUtils, json, topic, on, domGeom, domClass, register, Deferred,
+], function (registerSuite, assert, Application, viewUtils, json, Deferred,
 	hideViewconfig) {
 	// -------------------------------------------------------------------------------------- //
 	// for hideViewSuite transition test
@@ -34,7 +29,6 @@ define([
 			hideViewContainer = document.createElement("div");
 			document.body.appendChild(hideViewContainer);
 			hideViewContainer.innerHTML = hideViewHtmlContent3;
-			//	register.parse(hideViewContainer);
 			hideViewNode = document.getElementById("hideViewApp3dviewStack");
 
 		},

--- a/tests/unit/historyController/Test.js
+++ b/tests/unit/historyController/Test.js
@@ -7,16 +7,12 @@ define([
 	"dapp/utils/view",
 	"dapp/utils/hash",
 	"dojo/json",
-	"dojo/topic",
-	"dojo/on",
-	"dojo/dom-geometry",
-	"dojo/dom-class",
 	"delite/register",
 	"dojo/Deferred",
 	"requirejs-text/text!dapp/tests/unit/historyController/app1.json",
 	"deliteful/LinearLayout",
 	"deliteful/ViewStack"
-], function (registerSuite, assert, Application, viewUtils, hash, json, topic, on, domGeom, domClass, register,
+], function (registerSuite, assert, Application, viewUtils, hash, json, register,
 	Deferred, historyControllerconfig1) {
 	// -------------------------------------------------------------------------------------- //
 	// for historyControllerSuite1 transition test
@@ -146,14 +142,13 @@ define([
 		"test history.back() to get back to hc1center2)": function () {
 			this.timeout = 20000;
 			var displayDeferred = new Deferred();
-			setupOnOnce(displayDeferred);
+			setupOnOnce(testApp, displayDeferred);
 			history.back();
 			return displayDeferred.then(function () {
 				var hc1center2content = document.getElementById("hc1center2");
 				var hc1center2View = viewUtils.getViewFromViewId(testApp, "hc1center2");
 				checkNodeVisibile(hc1center2content);
 				checkActivateCallCount(hc1center2View, 2, true);
-			}).then(function () {
 				var currentHash = window.location.hash;
 				assert.deepEqual(currentHash, "#hc1header1+hc1centerParent+hc1center2+hc1right1+hc1footer1",
 					" currentHash should be #hc1header1+hc1centerParent+hc1center2+hc1right1+hc1footer1");
@@ -164,14 +159,14 @@ define([
 		"test history.back() to get back to hc1center1)": function () {
 			this.timeout = 20000;
 			var displayDeferred = new Deferred();
-			setupOnOnce(displayDeferred);
+			setupOnOnce(testApp, displayDeferred);
 			history.back();
 			return displayDeferred.then(function () {
 				var hc1center1content = document.getElementById("hc1center1");
 				var hc1center1View = viewUtils.getViewFromViewId(testApp, "hc1center1");
-				checkNodeVisibile(hc1center1content);
+				//checkNodeVisibile(hc1center1content);
+				assert.isTrue(hc1center1content.style.display !== "none", "hc1center1content should be visible");
 				checkActivateCallCount(hc1center1View, 2, true);
-			}).then(function () {
 				var currentHash = window.location.hash;
 				assert.deepEqual(currentHash, "#hc1header1+hc1centerParent+hc1center1+hc1right1+hc1footer1",
 					" currentHash should be #hc1header1+hc1centerParent+hc1center1+hc1right1+hc1footer1");
@@ -182,7 +177,7 @@ define([
 		"test history.forward() to get to hc1center2)": function () {
 			this.timeout = 20000;
 			var displayDeferred = new Deferred();
-			setupOnOnce(displayDeferred);
+			setupOnOnce(testApp, displayDeferred);
 			history.forward();
 			return displayDeferred.then(function () {
 				var hc1center2content = document.getElementById("hc1center2");
@@ -200,7 +195,7 @@ define([
 		"test history.forward() to get to hc1center3)": function () {
 			this.timeout = 11000;
 			var displayDeferred = new Deferred();
-			setupOnOnce(displayDeferred);
+			setupOnOnce(testApp, displayDeferred);
 			history.forward();
 			return displayDeferred.then(function () {
 				var hc1center3content = document.getElementById("hc1center3");
@@ -234,7 +229,7 @@ define([
 		"test history.back() to get back to hc1right1)": function () {
 			this.timeout = 20000;
 			var displayDeferred = new Deferred();
-			setupOnOnce(displayDeferred);
+			setupOnOnce(testApp, displayDeferred);
 			history.back();
 			return displayDeferred.then(function () {
 				var hc1rightPane = document.getElementById("hc1rightPane");
@@ -253,7 +248,7 @@ define([
 		"test history.forward() to hide hc1right1)": function () {
 			this.timeout = 20000;
 			var displayDeferred = new Deferred();
-			setupOnOnce(displayDeferred);
+			setupOnOnce(testApp, displayDeferred);
 			history.forward();
 			return displayDeferred.then(function () {
 				var hc1rightPane = document.getElementById("hc1rightPane");
@@ -437,7 +432,7 @@ define([
 		"test history.back() to get back to hc1leftParent,hc1left2)": function () {
 			this.timeout = 20000;
 			var displayDeferred = new Deferred();
-			setupOnOnce(displayDeferred);
+			setupOnOnce(testApp, displayDeferred);
 			history.back();
 			return displayDeferred.then(function () {
 				var hc1left2content = document.getElementById("hc1leftParent_hc1left2");
@@ -464,7 +459,7 @@ define([
 		"test history.forward() to get back to hc1leftParent,hc1left1 with parent and child params)": function () {
 			this.timeout = 20000;
 			var displayDeferred = new Deferred();
-			setupOnOnce(displayDeferred);
+			setupOnOnce(testApp, displayDeferred);
 			history.forward();
 			return displayDeferred.then(function () {
 				var hc1left1content = document.getElementById("hc1leftParent_hc1left1");
@@ -564,7 +559,7 @@ define([
 		"test history.back() to get back to hc1leftParent,hc1left2 with viewData)": function () {
 			this.timeout = 20000;
 			var displayDeferred = new Deferred();
-			setupOnOnce(displayDeferred);
+			setupOnOnce(testApp, displayDeferred);
 			history.back();
 			return displayDeferred.then(function () {
 				var hc1left2content = document.getElementById("hc1leftParent_hc1left2");
@@ -588,7 +583,7 @@ define([
 		"test history.forward() to get back to hc1leftParent,hc1left1 with viewData)": function () {
 			this.timeout = 20000;
 			var displayDeferred = new Deferred();
-			setupOnOnce(displayDeferred);
+			setupOnOnce(testApp, displayDeferred);
 			history.forward();
 			return displayDeferred.then(function () {
 				var hc1left1content = document.getElementById("hc1leftParent_hc1left1");
@@ -658,7 +653,7 @@ define([
 		"test history.back() to get back to hc1leftParent,hc1left2 with hash set)": function () {
 			this.timeout = 20000;
 			var displayDeferred = new Deferred();
-			setupOnOnce(displayDeferred);
+			setupOnOnce(testApp, displayDeferred);
 			history.back();
 			return displayDeferred.then(function () {
 				var hc1left2content = document.getElementById("hc1leftParent_hc1left2");
@@ -675,7 +670,7 @@ define([
 		"test history.forward() to get back to hc1leftParent,hc1left1 with hash set)": function () {
 			this.timeout = 20000;
 			var displayDeferred = new Deferred();
-			setupOnOnce(displayDeferred);
+			setupOnOnce(testApp, displayDeferred);
 			history.forward();
 			return displayDeferred.then(function () {
 				var hc1left1content = document.getElementById("hc1leftParent_hc1left1");
@@ -701,14 +696,15 @@ define([
 
 	registerSuite(historyControllerSuite1);
 
-	function setupOnOnce(displayDeferred) {
-		on.once(document, "dapp-finished-transition", function () {
+	function setupOnOnce(testApp, displayDeferred) {
+		var signal = testApp.on("dapp-finished-transition", function () {
 			displayDeferred.resolve();
+			signal.unadvise();
 		});
 	}
 
 	function checkNodeVisibile(target) {
-		assert.isTrue(target.style.display !== "none");
+		assert.isTrue(target.style.display !== "none", target.id+" should be visible, but it is not");
 	}
 
 	function checkActivateCallCount(view, count, skipActiveCheck) {

--- a/tests/unit/historyController/centerController1.js
+++ b/tests/unit/historyController/centerController1.js
@@ -27,9 +27,6 @@ define([], function () {
 			//console.log("app-view:", "afterActivate called for [" + this.viewName + "] with previousView.id =[" +
 			//	(previousView ? previousView.id : "") + "] with viewData=", viewData);
 			this._afterActivateCallCount++;
-			this.app.emit("afterActivateCalled", {
-				view: this
-			});
 		},
 		afterDeactivate: function ( /*nextView*/ ) {
 			//console.log("app-view:", "afterDeactivate called for [" + this.viewName + "] with previousView.id =[" +

--- a/tests/unit/historyController/footerController1.js
+++ b/tests/unit/historyController/footerController1.js
@@ -22,9 +22,6 @@ define([], function () {
 			//console.log("app-view:", "afterActivate called for [" + this.viewName + "] with previousView.id =[" +
 			//	(previousView ? previousView.id : "") + "] with viewData=", viewData);
 			this._afterActivateCallCount++;
-			this.app.emit("afterActivateCalled", {
-				view: this
-			});
 		},
 		afterDeactivate: function ( /*nextView*/ ) {
 			//console.log("app-view:", "afterDeactivate called for [" + this.viewName + "] with previousView.id =[" +

--- a/tests/unit/historyController/headerController1.js
+++ b/tests/unit/historyController/headerController1.js
@@ -22,9 +22,6 @@ define([], function () {
 			//console.log("app-view:", "afterActivate called for [" + this.viewName + "] with previousView.id =[" +
 			//	(previousView ? previousView.id : "") + "] with viewData=", viewData);
 			this._afterActivateCallCount++;
-			this.app.emit("afterActivateCalled", {
-				view: this
-			});
 		},
 		afterDeactivate: function ( /*nextView*/ ) {
 			//console.log("app-view:", "afterDeactivate called for [" + this.viewName + "] with previousView.id =[" +

--- a/tests/unit/historyController/leftController1.js
+++ b/tests/unit/historyController/leftController1.js
@@ -28,9 +28,6 @@ define([], function () {
 			//console.log("app-view:", "afterActivate called for [" + this.viewName + "] with previousView.id =[" +
 			//	(previousView ? previousView.id : "") + "] with viewData=", viewData);
 			this._afterActivateCallCount++;
-			this.app.emit("afterActivateCalled", {
-				view: this
-			});
 		},
 		afterDeactivate: function ( /*nextView*/ ) {
 			//console.log("app-view:", "afterDeactivate called for [" + this.viewName + "] with previousView.id =[" +

--- a/tests/unit/historyController/parentController1.js
+++ b/tests/unit/historyController/parentController1.js
@@ -23,9 +23,6 @@ define([], function () {
 			//console.log("app-view:", "afterActivate called for [" + this.viewName + "] with previousView.id =[" +
 			//	(previousView ? previousView.id : "") + "] with viewData=", viewData);
 			this._afterActivateCallCount++;
-			this.app.emit("afterActivateCalled", {
-				view: this
-			}); // do not do this for the parentView
 		},
 		afterDeactivate: function ( /*nextView*/ ) {
 			//console.log("app-view:", "afterDeactivate called for [" + this.viewName + "] with previousView.id =[" +

--- a/tests/unit/historyController/rightController1.js
+++ b/tests/unit/historyController/rightController1.js
@@ -27,9 +27,6 @@ define([], function () {
 			//console.log("app-view:", "afterActivate called for [" + this.viewName + "] with previousView.id =[" +
 			//	(previousView ? previousView.id : "") + "] with viewData=", viewData);
 			this._afterActivateCallCount++;
-			this.app.emit("afterActivateCalled", {
-				view: this
-			});
 		},
 		afterDeactivate: function ( /*nextView*/ ) {
 			//console.log("app-view:", "afterDeactivate called for [" + this.viewName + "] with previousView.id =[" +

--- a/tests/unit/multipleAndNestedViewsActivateCalls/Test.js
+++ b/tests/unit/multipleAndNestedViewsActivateCalls/Test.js
@@ -5,16 +5,12 @@ define([
 	"dapp/Application",
 	"dapp/utils/view",
 	"dojo/json",
-	"dojo/topic",
-	"dojo/on",
-	"dojo/dom-geometry",
-	"dojo/dom-class",
 	"delite/register",
 	"dojo/Deferred",
 	"requirejs-text/text!dapp/tests/unit/multipleAndNestedViewsActivateCalls/app1.json",
 	"deliteful/LinearLayout",
 	"deliteful/ViewStack"
-], function (registerSuite, assert, Application, viewUtils, json, topic, on, domGeom, domClass, register, Deferred,
+], function (registerSuite, assert, Application, viewUtils, json, register, Deferred,
 	multipleAndNestedViewsActivateCallsconfig1) {
 	// -------------------------------------------------------------------------------------- //
 	// for multipleAndNestedViewsActivateCallsSuite1 transition test

--- a/tests/unit/multipleAndNestedViewsActivateCalls/TestConstraints.js
+++ b/tests/unit/multipleAndNestedViewsActivateCalls/TestConstraints.js
@@ -5,16 +5,12 @@ define([
 	"dapp/Application",
 	"dapp/utils/view",
 	"dojo/json",
-	"dojo/topic",
-	"dojo/on",
-	"dojo/dom-geometry",
-	"dojo/dom-class",
 	"delite/register",
 	"dojo/Deferred",
 	"requirejs-text/text!dapp/tests/unit/multipleAndNestedViewsActivateCalls/app1Constraints.json",
 	"deliteful/LinearLayout",
 	"deliteful/ViewStack"
-], function (registerSuite, assert, Application, viewUtils, json, topic, on, domGeom, domClass, register, Deferred,
+], function (registerSuite, assert, Application, viewUtils, json, register, Deferred,
 	multipleAndNestedViewsActivateCallsconfig1) {
 	// -------------------------------------------------------------------------------------- //
 	// for multipleAndNestedViewsActivateCallsConstraintsSuite1 transition test

--- a/tests/unit/nestedViewsActivateCalls/Test.js
+++ b/tests/unit/nestedViewsActivateCalls/Test.js
@@ -5,16 +5,11 @@ define([
 	"dapp/Application",
 	"dapp/utils/view",
 	"dojo/json",
-	"dojo/topic",
-	"dojo/on",
-	"dojo/dom-geometry",
-	"dojo/dom-class",
-	"delite/register",
 	"dojo/Deferred",
 	"requirejs-text/text!dapp/tests/unit/nestedViewsActivateCalls/app1.json",
 	"deliteful/LinearLayout",
 	"deliteful/ViewStack"
-], function (registerSuite, assert, Application, viewUtils, json, topic, on, domGeom, domClass, register, Deferred,
+], function (registerSuite, assert, Application, viewUtils, json, Deferred,
 	nestedViewsActivateCallsconfig1) {
 	// -------------------------------------------------------------------------------------- //
 	// for nestedViewsActivateCallsSuite1 transition test

--- a/tests/unit/nlsLabels/Test.js
+++ b/tests/unit/nlsLabels/Test.js
@@ -5,16 +5,11 @@ define([
 	"dapp/Application",
 	"dapp/utils/view",
 	"dojo/json",
-	"dojo/topic",
-	"dojo/on",
-	"dojo/dom-geometry",
-	"dojo/dom-class",
-	"delite/register",
 	"dojo/Deferred",
 	"requirejs-text/text!dapp/tests/unit/nlsLabels/app.json",
 	"deliteful/LinearLayout",
 	"deliteful/ViewStack"
-], function (registerSuite, assert, Application, viewUtils, json, topic, on, domGeom, domClass, register, Deferred,
+], function (registerSuite, assert, Application, viewUtils, json, Deferred,
 	nlsLabelsconfig3) {
 	// -------------------------------------------------------------------------------------- //
 	// TODO: should add a nested nls test with strings at the parent view available to the child view.
@@ -35,7 +30,6 @@ define([
 			nlsLabelsContainer3 = document.createElement("div");
 			document.body.appendChild(nlsLabelsContainer3);
 			nlsLabelsContainer3.innerHTML = nlsLabelsHtmlContent3;
-			//	register.parse(nlsLabelsContainer3);
 			nlsLabelsNode3 = document.getElementById("nlsLabelsAppdviewStack");
 		},
 		"test initial view and nls labels": function () {

--- a/tests/unit/sidePaneViewsActivateCalls/Test.js
+++ b/tests/unit/sidePaneViewsActivateCalls/Test.js
@@ -6,16 +6,12 @@ define([
 	"dapp/Application",
 	"dapp/utils/view",
 	"dojo/json",
-	"dojo/topic",
-	"dojo/on",
-	"dojo/dom-geometry",
-	"dojo/dom-class",
 	"delite/register",
 	"dojo/Deferred",
 	"requirejs-text/text!dapp/tests/unit/sidePaneViewsActivateCalls/app1.json",
 	"deliteful/LinearLayout",
 	"deliteful/ViewStack"
-], function (registerSuite, assert, Application, viewUtils, json, topic, on, domGeom, domClass, register, Deferred,
+], function (registerSuite, assert, Application, viewUtils, json, register, Deferred,
 	sidePaneViewsActivateCallsconfig1) {
 	// -------------------------------------------------------------------------------------- //
 	// for sidePaneViewsActivateCallsSuite1 transition test
@@ -174,7 +170,7 @@ define([
 	registerSuite(sidePaneViewsActivateCallsSuite1);
 
 	function checkNodeVisibile(target) {
-		assert.isTrue(target.style.display !== "none");
+		assert.isTrue(target.style.display !== "none", target.id+" should be visible, but it is not");
 	}
 
 	function checkActivateCallCount(view, count, skipActiveCheck) {

--- a/tests/unit/sidePaneViewsActivateCalls/centerController1.js
+++ b/tests/unit/sidePaneViewsActivateCalls/centerController1.js
@@ -27,9 +27,6 @@ define([], function () {
 			//console.log("app-view:", "afterActivate called for [" + this.viewName + "] with previousView.id =[" +
 			//	(previousView ? previousView.id : "") + "] with viewData=", viewData);
 			this._afterActivateCallCount++;
-			this.app.emit("afterActivateCalled", {
-				view: this
-			});
 		},
 		afterDeactivate: function ( /*nextView*/ ) {
 			//console.log("app-view:", "afterDeactivate called for [" + this.viewName + "] with previousView.id =[" +

--- a/tests/unit/sidePaneViewsActivateCalls/footerController1.js
+++ b/tests/unit/sidePaneViewsActivateCalls/footerController1.js
@@ -22,9 +22,6 @@ define([], function () {
 			//console.log("app-view:", "afterActivate called for [" + this.viewName + "] with previousView.id =[" +
 			//	(previousView ? previousView.id : "") + "] with viewData=", viewData);
 			this._afterActivateCallCount++;
-			this.app.emit("afterActivateCalled", {
-				view: this
-			});
 		},
 		afterDeactivate: function ( /*nextView*/ ) {
 			//console.log("app-view:", "afterDeactivate called for [" + this.viewName + "] with previousView.id =[" +

--- a/tests/unit/sidePaneViewsActivateCalls/headerController1.js
+++ b/tests/unit/sidePaneViewsActivateCalls/headerController1.js
@@ -22,9 +22,6 @@ define([], function () {
 			//console.log("app-view:", "afterActivate called for [" + this.viewName + "] with previousView.id =[" +
 			//	(previousView ? previousView.id : "") + "] with viewData=", viewData);
 			this._afterActivateCallCount++;
-			this.app.emit("afterActivateCalled", {
-				view: this
-			});
 		},
 		afterDeactivate: function ( /*nextView*/ ) {
 			//console.log("app-view:", "afterDeactivate called for [" + this.viewName + "] with previousView.id =[" +

--- a/tests/unit/sidePaneViewsActivateCalls/leftController1.js
+++ b/tests/unit/sidePaneViewsActivateCalls/leftController1.js
@@ -27,9 +27,6 @@ define([], function () {
 			//console.log("app-view:", "afterActivate called for [" + this.viewName + "] with previousView.id =[" +
 			//	(previousView ? previousView.id : "") + "] with viewData=", viewData);
 			this._afterActivateCallCount++;
-			this.app.emit("afterActivateCalled", {
-				view: this
-			});
 		},
 		afterDeactivate: function ( /*nextView*/ ) {
 			//console.log("app-view:", "afterDeactivate called for [" + this.viewName + "] with previousView.id =[" +

--- a/tests/unit/sidePaneViewsActivateCalls/parentController1.js
+++ b/tests/unit/sidePaneViewsActivateCalls/parentController1.js
@@ -22,9 +22,6 @@ define([], function () {
 			//console.log("app-view:", "afterActivate called for [" + this.viewName + "] with previousView.id =[" +
 			//	(previousView ? previousView.id : "") + "] with viewData=", viewData);
 			this._afterActivateCallCount++;
-			this.app.emit("afterActivateCalled", {
-				view: this
-			}); // do not do this for the parentView
 		},
 		afterDeactivate: function ( /*nextView*/ ) {
 			//console.log("app-view:", "afterDeactivate called for [" + this.viewName + "] with previousView.id =[" +

--- a/tests/unit/sidePaneViewsActivateCalls/rightController1.js
+++ b/tests/unit/sidePaneViewsActivateCalls/rightController1.js
@@ -27,9 +27,6 @@ define([], function () {
 			//console.log("app-view:", "afterActivate called for [" + this.viewName + "] with previousView.id =[" +
 			//	(previousView ? previousView.id : "") + "] with viewData=", viewData);
 			this._afterActivateCallCount++;
-			this.app.emit("afterActivateCalled", {
-				view: this
-			});
 		},
 		afterDeactivate: function ( /*nextView*/ ) {
 			//console.log("app-view:", "afterDeactivate called for [" + this.viewName + "] with previousView.id =[" +

--- a/tests/unit/transitionVisibility/Test.js
+++ b/tests/unit/transitionVisibility/Test.js
@@ -4,15 +4,12 @@ define([
 	"intern/chai!assert",
 	"dapp/Application",
 	"dojo/json",
-	"dojo/on",
-	"dojo/dom-geometry",
-	"dojo/dom-class",
 	"delite/register",
 	"dojo/Deferred",
 	"requirejs-text/text!dapp/tests/unit/transitionVisibility/app.json",
 	"deliteful/LinearLayout",
 	"deliteful/ViewStack"
-], function (registerSuite, assert, Application, json, on, domGeom, domClass, register, Deferred,
+], function (registerSuite, assert, Application, json, register, Deferred,
 	transitionVisibilityconfig) {
 	// -------------------------------------------------------------------------------------- //
 	// for transitionVisibilitySuite
@@ -58,8 +55,9 @@ define([
 			this.timeout = 20000;
 			var displayDeferred = new Deferred();
 
-			on.once(transitionVisibilityNode3, "delite-after-show", function () {
+			var sig = transitionVisibilityNode3.on("delite-after-show", function () {
 				displayDeferred.resolve();
+				sig.remove();
 			});
 			transitionVisibilityNode3.show("transitionVisibilityAppHome3NoController");
 

--- a/tests/unit/viewDataAndParams/Test.js
+++ b/tests/unit/viewDataAndParams/Test.js
@@ -5,16 +5,11 @@ define([
 	"dapp/Application",
 	"dapp/utils/view",
 	"dojo/json",
-	"dojo/topic",
-	"dojo/on",
-	"dojo/dom-geometry",
-	"dojo/dom-class",
-	"delite/register",
 	"dojo/Deferred",
 	"requirejs-text/text!dapp/tests/unit/viewDataAndParams/app.json",
 	"deliteful/LinearLayout",
 	"deliteful/ViewStack"
-], function (registerSuite, assert, Application, viewUtils, json, topic, on, domGeom, domClass, register, Deferred,
+], function (registerSuite, assert, Application, viewUtils, json, Deferred,
 	viewDataconfig3) {
 	// -------------------------------------------------------------------------------------- //
 	// for viewDataSuite transition test
@@ -34,7 +29,6 @@ define([
 			viewDataContainer3 = document.createElement("div");
 			document.body.appendChild(viewDataContainer3);
 			viewDataContainer3.innerHTML = viewDataHtmlContent3;
-			//	register.parse(viewDataContainer3);
 			viewDataNode3 = document.getElementById("viewDataAndParamsAppdviewStack");
 		},
 		"test initial view": function () {

--- a/tests/unit/viewDataAndParams/parentController1.js
+++ b/tests/unit/viewDataAndParams/parentController1.js
@@ -23,9 +23,6 @@ define([], function () {
 			//console.log("app-view:", "afterActivate called for [" + this.viewName + "] with previousView.id =[" +
 			//	(previousView ? previousView.id : "") + "] with viewData=", viewData);
 			this._afterActivateCallCount++;
-			this.app.emit("afterActivateCalled", {
-				view: this
-			}); // do not do this for the parentView
 		},
 		afterDeactivate: function ( /*nextView*/ ) {
 			//console.log("app-view:", "afterDeactivate called for [" + this.viewName + "] with previousView.id =[" +

--- a/tests/unit/viewLayout/Test.js
+++ b/tests/unit/viewLayout/Test.js
@@ -4,7 +4,6 @@ define([
 	"intern/chai!assert",
 	"dapp/Application",
 	"dojo/json",
-	"dojo/on",
 	"dojo/dom-geometry",
 	"dojo/dom-class",
 	"delite/register",
@@ -12,7 +11,7 @@ define([
 	"requirejs-text/text!dapp/tests/unit/viewLayout/app.json",
 	"deliteful/LinearLayout",
 	"deliteful/ViewStack"
-], function (registerSuite, assert, Application, json, on, domGeom, domClass, register, Deferred,
+], function (registerSuite, assert, Application, json, domGeom, domClass, register, Deferred,
 	viewLayoutconfig) {
 	// -------------------------------------------------------------------------------------- //
 	// for viewLayoutSuite


### PR DESCRIPTION
...Also removing more dojo dependencies like dojo/on, dojo/wondow, and dojo/evented. Along with those changes I have updated the controller event processing to fix #19
Specific Changes: 
- changed dapp-status-change events to be emitted from the app instead of document and to remove STARTING since it would never be seen by the app.
- changed "dapp-display" event to be emitted from the app instead of document.
- updated Application to exend decor/evented instead of dojo/evented.
- updated Controller to handle binding all app events and using destroy to remove the event listeners, and to support mapEvents to map document or window events to app events.
- updated History controller to use the mapEvent for window popstate to app popstate, and to stop using dojo/on.
- updated Load controller to remove the use of dojo/on, and to use the mapEvent for document delite-display-load to app delite-display-load.
- updated Logger controller to use dcl/advise instead of dojo/aspect, removed the use of dojo/on, and added code to log all app emits.
- updated Init controller to remove the use of dojo/on and dojo/lang.
- updated Transition controller to remove the use of dojo/on, and changed "dapp-finished-transition" to emit on the app instead of document.
- updated many tests to remove the use dojo/on, and other unused dojo dependencies and defines.
