### PR TITLE
Update to make the view be the domNode instead of having a view.domNode....

### DIFF
--- a/Application.js
+++ b/Application.js
@@ -14,7 +14,7 @@ define(["require", "dcl/dcl", "decor/Stateful", "decor/Evented", "dojo/Deferred"
 			constructor: function (params, node) {
 				dcl.mix(this, params);
 				this.domNode = node;
-				this.children = {};
+				this.childViews = {};
 				this.loadedStores = {};
 				this.loadedControllers = [];
 			},

--- a/ViewBase.js
+++ b/ViewBase.js
@@ -1,4 +1,4 @@
-define(["require", "dojo/when", "dcl/dcl", "dojo/Deferred", "./utils/view"],
+define(["require", "dojo/when", "dcl/dcl", "dojo/Deferred", "dapp/utils/view"],
 	function (require, when, dcl, Deferred, viewUtils) {
 		return dcl(null, {
 			// summary:
@@ -18,7 +18,7 @@ define(["require", "dojo/when", "dcl/dcl", "dojo/Deferred", "./utils/view"],
 				//		- children: children views
 				this.id = "";
 				this.viewName = "";
-				this.children = {};
+				this.childViews = {};
 				this.selectedChildren = {};
 				this.loadedStores = {};
 				this.transitionCount = 0;
@@ -96,6 +96,7 @@ define(["require", "dojo/when", "dcl/dcl", "dojo/Deferred", "./utils/view"],
 				if (!this.hasOwnProperty("constraint")) {
 					this.constraint = this.domNode.getAttribute("data-app-constraint") ||
 						viewUtils.getDefaultConstraint(this.id, this.parentNode);
+					this.domNode.constraint = this.constraint;
 				}
 				viewUtils.register(this.constraint);
 
@@ -119,7 +120,7 @@ define(["require", "dojo/when", "dcl/dcl", "dojo/Deferred", "./utils/view"],
 				if (!this.controller) {
 					this.controller = "dapp/ViewBase";
 				}
-				if (!this.controller) { // no longer using this.controller === "none", if we dont have one it means none
+				if (!this.controller) {
 					viewControllerDef.resolve(true);
 					return viewControllerDef;
 				} else {
@@ -157,9 +158,10 @@ define(["require", "dojo/when", "dcl/dcl", "dojo/Deferred", "./utils/view"],
 				//		view life cycle afterDeactivate()
 			},
 
-			destroy: function () {
+			beforeDestroy: function () {
 				// summary:
-				//		view life cycle destroy()
+				//		view life cycle beforeDestroy() to do controller specific cleanup
 			}
+
 		});
 	});

--- a/controllers/Logger.js
+++ b/controllers/Logger.js
@@ -121,6 +121,9 @@ define(
 						console.log("> delite-display-load fired no event.dapp with event.dest=[" + event.dest +
 							"] event.hide=[" + event.hide + "] this.app.id=[" + this.app.id + "]");
 					}
+					if (typeof event.dest !== "string") {
+						return;
+					}
 					if (event.loadDeferred) {
 						event.loadDeferred.then(function (value) {
 							console.log("  < back from delite-display-load resolveView with value.child.id=[" +
@@ -128,7 +131,7 @@ define(
 								(value.dapp && value.dapp.parentView ? value.dapp.parentView.id : "") + "]");
 						});
 					}
-					if (event.dapp.dest && !event.dapp.hide) {
+					if (event.dapp && event.dapp.dest && !event.dapp.hide) {
 						var onbeforeShowDisplayHandle = event.target.on("delite-before-show", function (value) {
 							this.logBeforeAfterShowHideDisplay(self.app, value, event, true, false,
 								onbeforeShowDisplayHandle);

--- a/controllers/delite/Transition.js
+++ b/controllers/delite/Transition.js
@@ -136,13 +136,13 @@ define(["dcl/dcl", "dojo/when", "dojo/Deferred", "dojo/promise/all", "../../Cont
 				event.dapp.hide = true;
 				event.dapp.viewPath = viewPath;
 				event.dapp.parentView = viewUtils.getParentViewFromViewId(this.app, viewPath.lastViewId);
-				event.dest = event.dapp.parentView.children[viewPath.lastViewId].viewName;
+				event.dest = event.dapp.parentView.childViews[viewPath.lastViewId].viewName;
 				var self = this;
 				var p = self._getParentNode(event);
 				if (!p.hide) { // should have a hide function, if not
 					//TODO: ELC need a test for this!!
 					console.error("No hide function available on parentNode for viewTarget =" + viewTarget);
-					event.dapp.nextView = event.dapp.parentView.children[viewTarget];
+					event.dapp.nextView = event.dapp.parentView.childViews[viewTarget];
 					var parentSelChild = viewUtils.getSelectedChild(event.dapp.parentView,
 						event.dapp.nextView.constraint);
 					event.dapp.nextView.viewShowing = false;

--- a/tests/functional/simple1/centerController1.js
+++ b/tests/functional/simple1/centerController1.js
@@ -7,16 +7,16 @@ define([], function () {
 		_afterActivateCallCount: 0,
 		_afterDeactivateCallCount: 0,
 		init: function () {
-			this.domNode.name = this.id;
+			this.name = this.id;
 		},
 		beforeActivate: function ( /*previousView, viewData*/ ) {
 			//console.log("app-view:", "beforeActivate called for [" + this.viewName + "] with previousView.id =[" +
 			//	(previousView ? previousView.id : "") + "] with viewData=", viewData);
 			this._beforeActivateCallCount++;
 			if (this.id === "center1") {
-				this.domNode.style.backgroundColor = "cyan";
+				this.style.backgroundColor = "cyan";
 			} else {
-				this.domNode.style.backgroundColor = "green";
+				this.style.backgroundColor = "green";
 			}
 		},
 		beforeDeactivate: function ( /*nextView, viewData*/ ) {
@@ -34,8 +34,8 @@ define([], function () {
 			//	(nextView ? nextView.id : "") + "]");
 			this._afterDeactivateCallCount++;
 		},
-		destroy: function () {
-			//console.log("app-view:", " in [" + this.viewName + "] destroy called for [" + this.id + "]");
+		beforeDestroy: function () {
+			//console.log("app-view:", " in [" + this.viewName + "] beforeDestroy called for [" + this.id + "]");
 		}
 	};
 });

--- a/tests/functional/simple1/footerController1.js
+++ b/tests/functional/simple1/footerController1.js
@@ -7,7 +7,7 @@ define([], function () {
 		_afterActivateCallCount: 0,
 		_afterDeactivateCallCount: 0,
 		init: function () {
-			this.domNode.name = this.id;
+			this.name = this.id;
 		},
 		beforeActivate: function ( /*previousView, viewData*/ ) {
 			//console.log("app-view:", "beforeActivate called for [" + this.viewName + "] with previousView.id =[" +
@@ -29,8 +29,8 @@ define([], function () {
 			//	(nextView ? nextView.id : "") + "]");
 			this._afterDeactivateCallCount++;
 		},
-		destroy: function () {
-			//console.log("app-view:", " in [" + this.viewName + "] destroy called for [" + this.id + "]");
+		beforeDestroy: function () {
+			//console.log("app-view:", " in [" + this.viewName + "] beforeDestroy called for [" + this.id + "]");
 		}
 	};
 });

--- a/tests/functional/simple1/headerController1.js
+++ b/tests/functional/simple1/headerController1.js
@@ -7,7 +7,7 @@ define([], function () {
 		_afterActivateCallCount: 0,
 		_afterDeactivateCallCount: 0,
 		init: function () {
-			this.domNode.name = this.id;
+			this.name = this.id;
 		},
 		beforeActivate: function ( /*previousView, viewData*/ ) {
 			//console.log("app-view:", "beforeActivate called for [" + this.viewName + "] with previousView.id =[" +
@@ -29,8 +29,8 @@ define([], function () {
 			//	(nextView ? nextView.id : "") + "]");
 			this._afterDeactivateCallCount++;
 		},
-		destroy: function () {
-			//console.log("app-view:", " in [" + this.viewName + "] destroy called for [" + this.id + "]");
+		beforeDestroy: function () {
+			//console.log("app-view:", " in [" + this.viewName + "] beforeDestroy called for [" + this.id + "]");
 		}
 	};
 });

--- a/tests/functional/simple1/parentController1.js
+++ b/tests/functional/simple1/parentController1.js
@@ -30,7 +30,7 @@ define([], function () {
 			this._afterDeactivateCallCount++;
 		},
 		destroy: function () {
-			//console.log("app-view:", " in [" + this.viewName + "] destroy called for [" + this.id + "]");
+			//console.log("app-view:", " in [" + this.viewName + "] beforeDestroy called for [" + this.id + "]");
 		}
 	};
 });

--- a/tests/functional/simple1Test.js
+++ b/tests/functional/simple1Test.js
@@ -21,35 +21,35 @@ define([
 
 		"test defaultView sel111 initialized and active": function () {
 			return this.remote
-				.execute("return simple1App1.children.header1.initialized")
+				.execute("return simple1App1.childViews.header1.initialized")
 				.then(function (value) {
-					//console.log("value simple1App1.children.header1.initialized is = " + value);
-					assert.isTrue(value, "simple1App1.children.header1.initialized should be true");
+					//console.log("value simple1App1.childViews.header1.initialized is = " + value);
+					assert.isTrue(value, "simple1App1.childViews.header1.initialized should be true");
 				})
 				.end()
-				.execute("return simple1App1.children.header1._active")
-				.then(function (value) {
-					assert.isTrue(value);
-				})
-				.end()
-				.execute("return simple1App1.children.center1.initialized")
-				.then(function (value) {
-					//console.log("value simple1App1.children.center1.initialized is = " + value);
-					assert.isTrue(value, "simple1App1.children.center1.initialized should be true");
-				})
-				.end()
-				.execute("return simple1App1.children.center1._active")
+				.execute("return simple1App1.childViews.header1._active")
 				.then(function (value) {
 					assert.isTrue(value);
 				})
 				.end()
-				.execute("return simple1App1.children.footer1.initialized")
+				.execute("return simple1App1.childViews.center1.initialized")
 				.then(function (value) {
-					//console.log("value simple1App1.children.footer1.initialized is = " + value);
-					assert.isTrue(value, "simple1App1.children.footer1.initialized should be true");
+					//console.log("value simple1App1.childViews.center1.initialized is = " + value);
+					assert.isTrue(value, "simple1App1.childViews.center1.initialized should be true");
 				})
 				.end()
-				.execute("return simple1App1.children.footer1._active")
+				.execute("return simple1App1.childViews.center1._active")
+				.then(function (value) {
+					assert.isTrue(value);
+				})
+				.end()
+				.execute("return simple1App1.childViews.footer1.initialized")
+				.then(function (value) {
+					//console.log("value simple1App1.childViews.footer1.initialized is = " + value);
+					assert.isTrue(value, "simple1App1.childViews.footer1.initialized should be true");
+				})
+				.end()
+				.execute("return simple1App1.childViews.footer1._active")
 				.then(function (value) {
 					assert.isTrue(value);
 				})
@@ -63,22 +63,22 @@ define([
 
 		"test defaultView sel111 activate calls": function () {
 			return this.remote
-				.execute("return simple1App1.children.header1._beforeActivateCallCount")
+				.execute("return simple1App1.childViews.header1._beforeActivateCallCount")
 				.then(function (value) {
 					assert.equal(1, value);
 				})
 				.end()
-				.execute("return simple1App1.children.header1.domNode.textContent")
+				.execute("return simple1App1.childViews.header1.textContent")
 				.then(function (value) {
 					assert(/header1/.test(value), "textContent (" + value + ") contains header1");
 				})
 				.end()
-				.execute("return simple1App1.children.center1.domNode.textContent")
+				.execute("return simple1App1.childViews.center1.textContent")
 				.then(function (value) {
 					assert(/center1/.test(value), "textContent (" + value + ") contains center1");
 				})
 				.end()
-				.execute("return simple1App1.children.footer1.domNode.textContent")
+				.execute("return simple1App1.childViews.footer1.textContent")
 				.then(function (value) {
 					assert(/footer1/.test(value), "textContent (" + value + ") contains footer1");
 				})
@@ -87,17 +87,17 @@ define([
 
 		"test defaultView sel111 textContent calls": function () {
 			return this.remote
-				.execute("return simple1App1.children.header1.domNode.textContent")
+				.execute("return simple1App1.childViews.header1.textContent")
 				.then(function (value) {
 					assert(/header1/.test(value), "textContent (" + value + ") contains header1");
 				})
 				.end()
-				.execute("return simple1App1.children.center1.domNode.textContent")
+				.execute("return simple1App1.childViews.center1.textContent")
 				.then(function (value) {
 					assert(/center1/.test(value), "textContent (" + value + ") contains center1");
 				})
 				.end()
-				.execute("return simple1App1.children.footer1.domNode.textContent")
+				.execute("return simple1App1.childViews.footer1.textContent")
 				.then(function (value) {
 					assert(/footer1/.test(value), "textContent (" + value + ") contains footer1");
 				})
@@ -106,21 +106,21 @@ define([
 
 		"test click sel222": function () {
 			return this.remote
-				.execute("return simple1App1.children.center1.domNode.getElementsByClassName('sel222')[0]")
+				.execute("return simple1App1.childViews.center1.getElementsByClassName('sel222')[0]")
 				.click()
 				.end()
 				.wait(500)
-				.execute("return simple1App1.children.header2.domNode.textContent")
+				.execute("return simple1App1.childViews.header2.textContent")
 				.then(function (value) {
 					assert(/header2/.test(value), "textContent (" + value + ") contains header2");
 				})
 				.end()
-				.execute("return simple1App1.children.center2.domNode.textContent")
+				.execute("return simple1App1.childViews.center2.textContent")
 				.then(function (value) {
 					assert(/center2/.test(value), "textContent (" + value + ") contains center2");
 				})
 				.end()
-				.execute("return simple1App1.children.footer2.domNode.textContent")
+				.execute("return simple1App1.childViews.footer2.textContent")
 				.then(function (value) {
 					assert(/footer2/.test(value), "textContent (" + value + ") contains footer2");
 				})
@@ -128,53 +128,53 @@ define([
 		},
 		"test sel222 initialized and active": function () {
 			return this.remote
-				.execute("return simple1App1.children.header2.initialized")
+				.execute("return simple1App1.childViews.header2.initialized")
 				.then(function (value) {
-					assert.isTrue(value, "simple1App1.children.header2.initialized should be true");
+					assert.isTrue(value, "simple1App1.childViews.header2.initialized should be true");
 				})
 				.end()
-				.execute("return simple1App1.children.header2._active")
+				.execute("return simple1App1.childViews.header2._active")
 				.then(function (value) {
-					assert.isTrue(value, "simple1App1.children.header2._active should be true");
+					assert.isTrue(value, "simple1App1.childViews.header2._active should be true");
 				})
 				.end()
-				.execute("return simple1App1.children.center2.initialized")
+				.execute("return simple1App1.childViews.center2.initialized")
 				.then(function (value) {
-					assert.isTrue(value, "simple1App1.children.center2.initialized should be true");
+					assert.isTrue(value, "simple1App1.childViews.center2.initialized should be true");
 				})
 				.end()
-				.execute("return simple1App1.children.center2._active")
+				.execute("return simple1App1.childViews.center2._active")
 				.then(function (value) {
-					assert.isTrue(value, "simple1App1.children.center2._active should be true");
+					assert.isTrue(value, "simple1App1.childViews.center2._active should be true");
 				})
 				.end()
-				.execute("return simple1App1.children.footer2.initialized")
+				.execute("return simple1App1.childViews.footer2.initialized")
 				.then(function (value) {
-					assert.isTrue(value, "simple1App1.children.footer2.initialized should be true");
+					assert.isTrue(value, "simple1App1.childViews.footer2.initialized should be true");
 				})
 				.end()
-				.execute("return simple1App1.children.footer2._active")
+				.execute("return simple1App1.childViews.footer2._active")
 				.then(function (value) {
-					assert.isTrue(value, "simple1App1.children.footer2._active should be true");
+					assert.isTrue(value, "simple1App1.childViews.footer2._active should be true");
 				})
 				.end();
 		},
 
 		"test sel222 active sel111 not active": function () {
 			return this.remote
-				.execute("return simple1App1.children.header1._active")
+				.execute("return simple1App1.childViews.header1._active")
 				.then(function (value) {
-					assert.isFalse(value, "simple1App1.children.header1._active should be false");
+					assert.isFalse(value, "simple1App1.childViews.header1._active should be false");
 				})
 				.end()
-				.execute("return simple1App1.children.center1._active")
+				.execute("return simple1App1.childViews.center1._active")
 				.then(function (value) {
-					assert.isFalse(value, "simple1App1.children.center1._active should be false");
+					assert.isFalse(value, "simple1App1.childViews.center1._active should be false");
 				})
 				.end()
-				.execute("return simple1App1.children.footer1._active")
+				.execute("return simple1App1.childViews.footer1._active")
 				.then(function (value) {
-					assert.isFalse(value, "simple1App1.children.footer1._active should be false");
+					assert.isFalse(value, "simple1App1.childViews.footer1._active should be false");
 				})
 				.end();
 		},
@@ -183,8 +183,8 @@ define([
 			return this.remote
 				.execute(function () {
 					return {
-						display: simple1App1.children.header1.domNode.style.display,
-						visibility: simple1App1.children.header1.domNode.style.visibility
+						display: simple1App1.childViews.header1.style.display,
+						visibility: simple1App1.childViews.header1.style.visibility
 					};
 				})
 				.then(function (style) {
@@ -194,8 +194,8 @@ define([
 				.end()
 				.execute(function () {
 					return {
-						display: simple1App1.children.center1.domNode.style.display,
-						visibility: simple1App1.children.center1.domNode.style.visibility
+						display: simple1App1.childViews.center1.style.display,
+						visibility: simple1App1.childViews.center1.style.visibility
 					};
 				})
 				.then(function (style) {
@@ -205,8 +205,8 @@ define([
 				.end()
 				.execute(function () {
 					return {
-						display: simple1App1.children.footer1.domNode.style.display,
-						visibility: simple1App1.children.footer1.domNode.style.visibility
+						display: simple1App1.childViews.footer1.style.display,
+						visibility: simple1App1.childViews.footer1.style.visibility
 					};
 				})
 				.then(function (style) {
@@ -216,8 +216,8 @@ define([
 				.end()
 				.execute(function () {
 					return {
-						display: simple1App1.children.header2.domNode.style.display,
-						visibility: simple1App1.children.header2.domNode.style.visibility
+						display: simple1App1.childViews.header2.style.display,
+						visibility: simple1App1.childViews.header2.style.visibility
 					};
 				})
 				.then(function (style) {
@@ -227,8 +227,8 @@ define([
 				.end()
 				.execute(function () {
 					return {
-						display: simple1App1.children.center2.domNode.style.display,
-						visibility: simple1App1.children.center2.domNode.style.visibility
+						display: simple1App1.childViews.center2.style.display,
+						visibility: simple1App1.childViews.center2.style.visibility
 					};
 				})
 				.then(function (style) {
@@ -238,8 +238,8 @@ define([
 				.end()
 				.execute(function () {
 					return {
-						display: simple1App1.children.footer2.domNode.style.display,
-						visibility: simple1App1.children.footer2.domNode.style.visibility
+						display: simple1App1.childViews.footer2.style.display,
+						visibility: simple1App1.childViews.footer2.style.visibility
 					};
 				})
 				.then(function (style) {
@@ -251,12 +251,12 @@ define([
 
 		"test sel222 activate calls": function () {
 			return this.remote
-				.execute("return simple1App1.children.header2._beforeActivateCallCount")
+				.execute("return simple1App1.childViews.header2._beforeActivateCallCount")
 				.then(function (value) {
 					assert.equal(1, value);
 				})
 				.end()
-				.execute("return simple1App1.children.center2.domNode.textContent")
+				.execute("return simple1App1.childViews.center2.textContent")
 				.then(function (value) {
 					assert(/center2/.test(value), "textContent (" + value + ") contains center2");
 				})
@@ -265,17 +265,17 @@ define([
 
 		"test sel222 textContent calls": function () {
 			return this.remote
-				.execute("return simple1App1.children.header2.domNode.textContent")
+				.execute("return simple1App1.childViews.header2.textContent")
 				.then(function (value) {
 					assert(/header2/.test(value), "textContent (" + value + ") contains header1");
 				})
 				.end()
-				.execute("return simple1App1.children.center2.domNode.textContent")
+				.execute("return simple1App1.childViews.center2.textContent")
 				.then(function (value) {
 					assert(/center2/.test(value), "textContent (" + value + ") contains center2");
 				})
 				.end()
-				.execute("return simple1App1.children.footer2.domNode.textContent")
+				.execute("return simple1App1.childViews.footer2.textContent")
 				.then(function (value) {
 					assert(/footer2/.test(value), "textContent (" + value + ") contains footer2");
 				})
@@ -284,7 +284,7 @@ define([
 
 		"test footer1": function () {
 			return this.remote
-				.execute("return simple1App1.children.footer1.domNode.textContent")
+				.execute("return simple1App1.childViews.footer1.textContent")
 				.then(function (value) {
 					assert(/footer1/.test(value), "textContent (" + value + ") contains footer1");
 				})

--- a/tests/unit/appStatus/viewController1.js
+++ b/tests/unit/appStatus/viewController1.js
@@ -3,7 +3,7 @@ define([], function () {
 	return {
 		name: "",
 		init: function () {
-			this.domNode.name = this.id;
+			this.name = this.id;
 		},
 		beforeActivate: function ( /*previousView, viewData*/ ) {
 			//console.log("app-view:", "beforeActivate called for [" + this.viewName + "] with previousView.id =[" +
@@ -25,8 +25,8 @@ define([], function () {
 			//	(nextView ? nextView.id : "") + "]");
 			this._afterDeactivateCallCount++;
 		},
-		destroy: function () {
-			//console.log("app-view:", " in [" + this.viewName + "] destroy called for [" + this.id + "]");
+		beforeDestroy: function () {
+			console.log("app-view:", " in [" + this.viewName + "] beforeDestroy called for [" + this.id + "]");
 		}
 	};
 });

--- a/tests/unit/dstoreMemory/viewController.js
+++ b/tests/unit/dstoreMemory/viewController.js
@@ -9,8 +9,8 @@ define([],
 			_afterActivateCallCount: 0,
 			_afterDeactivateCallCount: 0,
 			init: function () {
-				this.domNode.name = this.id;
-				var list = this.domNode.ownerDocument.getElementById("list1");
+				this.name = this.id;
+				var list = this.ownerDocument.getElementById("list1");
 
 				// Different options for creating the store, 1. ObservableStore, add data below
 				//var ObservableMemoryStore = dcl([MemoryStore, Observable], {});
@@ -25,7 +25,7 @@ define([],
 				var dstoreMemoryApp = this.app;
 
 				// When the list is clicked, transition to dstoreMemoryAppHome2, pass the label of the selected item.
-				this.domNode.ownerDocument.getElementById("list1").on("click",
+				this.ownerDocument.getElementById("list1").on("click",
 					function ( /*MouseEvent*/ evt) {
 						var label = evt.target.innerText || evt.target.textContent || "";
 						var targetView = "dstoreMemoryAppHome2";
@@ -44,7 +44,7 @@ define([],
 				//	"] with previousView.id =[" + (previousView ? previousView.id : "") +
 				// "] with viewData=", viewData);
 				this._beforeActivateCallCount++;
-				this.domNode.lastSelection = viewData ? viewData.label : "";
+				this.lastSelection = viewData ? viewData.label : "";
 			},
 			beforeDeactivate: function ( /*nextView, viewData*/ ) {
 				//console.log("app-view:", "beforeDeactivate called for [" + this.viewName +
@@ -61,8 +61,8 @@ define([],
 				// "] with previousView.id =[" + (nextView ? nextView.id : "") + "]");
 				this._afterDeactivateCallCount++;
 			},
-			destroy: function () {
-				//console.log("app-view:", " in [" + this.viewName + "] destroy called for [" + this.id + "]");
+			beforeDestroy: function () {
+				console.log("app-view:", " in [" + this.viewName + "] beforeDestroy called for [" + this.id + "]");
 			}
 		};
 	});

--- a/tests/unit/dstoreMemory/viewController2.js
+++ b/tests/unit/dstoreMemory/viewController2.js
@@ -9,8 +9,8 @@ define([],
 			_afterActivateCallCount: 0,
 			_afterDeactivateCallCount: 0,
 			init: function () {
-				this.domNode.name = this.id;
-				var list = this.domNode.ownerDocument.getElementById("list2");
+				this.name = this.id;
+				var list = this.ownerDocument.getElementById("list2");
 				var dstoreMemoryApp = this.app;
 
 				// Different options for creating the store, 1. MemoryStore, add data below
@@ -22,7 +22,7 @@ define([],
 				list.store = this.loadedStores.list2Store;
 
 				// When the list is clicked, transition to dstoreMemoryAppHome2, pass the label of the selected item.
-				this.domNode.ownerDocument.getElementById("list2").on("click",
+				this.ownerDocument.getElementById("list2").on("click",
 					function ( /*MouseEvent*/ evt) {
 						var label = evt.target.innerText || evt.target.textContent || "";
 						var targetView = "dstoreMemoryAppHome1";
@@ -40,7 +40,7 @@ define([],
 				//console.log("app-view:", "beforeActivate called for [" + this.viewName +
 				// "] with previousView.id =[" + (previousView ? previousView.id : "") + "] with viewData=", viewData);
 				this._beforeActivateCallCount++;
-				this.domNode.lastSelection = viewData ? viewData.label : "";
+				this.lastSelection = viewData ? viewData.label : "";
 			},
 			beforeDeactivate: function ( /*nextView, viewData*/ ) {
 				//console.log("app-view:", "beforeDeactivate called for [" + this.viewName +
@@ -57,8 +57,8 @@ define([],
 				// "] with previousView.id =[" + (nextView ? nextView.id : "") + "]");
 				this._afterDeactivateCallCount++;
 			},
-			destroy: function () {
-				//console.log("app-view:", " in [" + this.viewName + "] destroy called for [" + this.id + "]");
+			beforeDestroy: function () {
+				//console.log("app-view:", " in [" + this.viewName + "] beforeDestroy called for [" + this.id + "]");
 			}
 		};
 	});

--- a/tests/unit/hideView/Test.js
+++ b/tests/unit/hideView/Test.js
@@ -66,7 +66,7 @@ define([
 				var hideViewApp3Home1 = document.getElementById("hideViewApp3Home1");
 				hideViewApp3Home1View = viewUtils.getViewFromViewId(testApp, "hideViewApp3Home1");
 				assert.isNull(hideViewApp3Home1);
-				assert.isNull(hideViewApp3Home1View.domNode.parentNode);
+				assert.isNull(hideViewApp3Home1View.parentNode);
 			});
 
 		},
@@ -103,7 +103,7 @@ define([
 				var hideViewApp3Home2 = document.getElementById("hideViewApp3Home2");
 				hideViewApp3Home2View = viewUtils.getViewFromViewId(testApp, "hideViewApp3Home2");
 				assert.isNull(hideViewApp3Home2);
-				assert.isNull(hideViewApp3Home2View.domNode.parentNode);
+				assert.isNull(hideViewApp3Home2View.parentNode);
 
 				// Now hideViewApp3Home2View ActivateCallCounts should be 1
 				var view = hideViewApp3Home2View;

--- a/tests/unit/hideView/viewController1.js
+++ b/tests/unit/hideView/viewController1.js
@@ -7,7 +7,7 @@ define([], function () {
 		_afterActivateCallCount: 0,
 		_afterDeactivateCallCount: 0,
 		init: function () {
-			this.domNode.name = this.id;
+			this.name = this.id;
 		},
 		beforeActivate: function (previousView, viewData) {
 			//console.log("app-view:", "beforeActivate called for [" + this.viewName + "] with previousView.id =[" +
@@ -29,10 +29,6 @@ define([], function () {
 			//console.log("app-view:", "afterDeactivate called for [" + this.viewName + "] with previousView.id =[" +
 			//	(nextView ? nextView.id : "") + "]");
 			this._afterDeactivateCallCount++;
-		},
-		// for now destroy function is required or an error can occur during dapp-unload-app or dapp-unload-view
-		destroy: function () {
-			//console.log("app-view:", " in [" + this.viewName + "] destroy called for [" + this.id + "]");
 		}
 	};
 });

--- a/tests/unit/historyController/Test.js
+++ b/tests/unit/historyController/Test.js
@@ -333,7 +333,7 @@ define([
 				var hc1right2content = hc1right2View.containerNode;
 				assert.isNotNull(hc1right2content, "hc1right2content must be here");
 				//	checkNodeVisibile(hc1right2content);
-				assert.isTrue(hc1right2View.domNode.style.display === "none");
+				assert.isTrue(hc1right2View.style.display === "none");
 				assert.isTrue(hc1rightPaneElem.style.display === "none");
 			});
 		},

--- a/tests/unit/historyController/centerController1.js
+++ b/tests/unit/historyController/centerController1.js
@@ -6,16 +6,16 @@ define([], function () {
 		_afterActivateCallCount: 0,
 		_afterDeactivateCallCount: 0,
 		init: function () {
-			this.domNode.name = this.id;
+			this.name = this.id;
 		},
 		beforeActivate: function ( /*previousView, viewData*/ ) {
 			//console.log("app-view:", "beforeActivate called for [" + this.viewName + "] with previousView.id =[" +
 			//	(previousView ? previousView.id : "") + "] with viewData=", viewData);
 			this._beforeActivateCallCount++;
 			if (this.id === "center1") {
-				this.domNode.style.backgroundColor = "cyan";
+				this.style.backgroundColor = "cyan";
 			} else {
-				this.domNode.style.backgroundColor = "green";
+				this.style.backgroundColor = "green";
 			}
 		},
 		beforeDeactivate: function ( /*nextView*/ ) {
@@ -32,9 +32,6 @@ define([], function () {
 			//console.log("app-view:", "afterDeactivate called for [" + this.viewName + "] with previousView.id =[" +
 			//	(nextView ? nextView.id : "") + "]");
 			this._afterDeactivateCallCount++;
-		},
-		destroy: function () {
-			//console.log("app-view:", " in [" + this.viewName + "] destroy called for [" + this.id + "]");
 		}
 	};
 });

--- a/tests/unit/historyController/footerController1.js
+++ b/tests/unit/historyController/footerController1.js
@@ -6,7 +6,7 @@ define([], function () {
 		_afterActivateCallCount: 0,
 		_afterDeactivateCallCount: 0,
 		init: function () {
-			this.domNode.name = this.id;
+			this.name = this.id;
 		},
 		beforeActivate: function ( /*previousView, viewData*/ ) {
 			//console.log("app-view:", "beforeActivate called for [" + this.viewName + "] with previousView.id =[" +
@@ -27,9 +27,6 @@ define([], function () {
 			//console.log("app-view:", "afterDeactivate called for [" + this.viewName + "] with previousView.id =[" +
 			//	(nextView ? nextView.id : "") + "]");
 			this._afterDeactivateCallCount++;
-		},
-		destroy: function () {
-			//console.log("app-view:", " in [" + this.viewName + "] destroy called for [" + this.id + "]");
 		}
 	};
 });

--- a/tests/unit/historyController/headerController1.js
+++ b/tests/unit/historyController/headerController1.js
@@ -6,7 +6,7 @@ define([], function () {
 		_afterActivateCallCount: 0,
 		_afterDeactivateCallCount: 0,
 		init: function () {
-			this.domNode.name = this.id;
+			this.name = this.id;
 		},
 		beforeActivate: function ( /*previousView, viewData*/ ) {
 			//console.log("app-view:", "beforeActivate called for [" + this.viewName + "] with previousView.id =[" +
@@ -28,8 +28,8 @@ define([], function () {
 			//	(nextView ? nextView.id : "") + "]");
 			this._afterDeactivateCallCount++;
 		},
-		destroy: function () {
-			//console.log("app-view:", " in [" + this.viewName + "] destroy called for [" + this.id + "]");
+		beforeDestroy: function () {
+			//console.log("app-view:", " in [" + this.viewName + "] beforeDestroy called for [" + this.id + "]");
 		}
 	};
 });

--- a/tests/unit/historyController/leftController1.js
+++ b/tests/unit/historyController/leftController1.js
@@ -6,7 +6,7 @@ define([], function () {
 		_afterActivateCallCount: 0,
 		_afterDeactivateCallCount: 0,
 		init: function () {
-			this.domNode.name = this.id;
+			this.name = this.id;
 		},
 		beforeActivate: function (previousView, viewData) {
 			//console.log("app-view:", "beforeActivate called for [" + this.viewName + "] with previousView.id =[" +
@@ -14,9 +14,9 @@ define([], function () {
 			this._beforeActivateCallCount++;
 			this.viewData = viewData;
 			if (this.id === "right1") {
-				this.domNode.style.backgroundColor = "darkgoldenrod";
+				this.style.backgroundColor = "darkgoldenrod";
 			} else {
-				this.domNode.style.backgroundColor = "orange";
+				this.style.backgroundColor = "orange";
 			}
 		},
 		beforeDeactivate: function ( /*nextView*/ ) {
@@ -34,8 +34,8 @@ define([], function () {
 			//	(nextView ? nextView.id : "") + "]");
 			this._afterDeactivateCallCount++;
 		},
-		destroy: function () {
-			//console.log("app-view:", " in [" + this.viewName + "] destroy called for [" + this.id + "]");
+		beforeDestroy: function () {
+			//console.log("app-view:", " in [" + this.viewName + "] beforeDestroy called for [" + this.id + "]");
 		}
 	};
 });

--- a/tests/unit/historyController/parentController1.js
+++ b/tests/unit/historyController/parentController1.js
@@ -6,7 +6,7 @@ define([], function () {
 		_afterActivateCallCount: 0,
 		_afterDeactivateCallCount: 0,
 		init: function () {
-			this.domNode.name = this.id;
+			this.name = this.id;
 		},
 		beforeActivate: function (previousView, viewData) {
 			//console.log("app-view:", "beforeActivate called for [" + this.viewName + "] with previousView.id =[" +
@@ -29,8 +29,8 @@ define([], function () {
 			//	(nextView ? nextView.id : "") + "]");
 			this._afterDeactivateCallCount++;
 		},
-		destroy: function () {
-			//console.log("app-view:", " in [" + this.viewName + "] destroy called for [" + this.id + "]");
+		beforeDestroy: function () {
+			//console.log("app-view:", " in [" + this.viewName + "] beforeDestroy called for [" + this.id + "]");
 		}
 	};
 });

--- a/tests/unit/historyController/rightController1.js
+++ b/tests/unit/historyController/rightController1.js
@@ -6,16 +6,16 @@ define([], function () {
 		_afterActivateCallCount: 0,
 		_afterDeactivateCallCount: 0,
 		init: function () {
-			this.domNode.name = this.id;
+			this.name = this.id;
 		},
 		beforeActivate: function ( /*previousView, viewData*/ ) {
 			//console.log("app-view:", "beforeActivate called for [" + this.viewName + "] with previousView.id =[" +
 			//	(previousView ? previousView.id : "") + "] with viewData=", viewData);
 			this._beforeActivateCallCount++;
 			if (this.id === "right1") {
-				this.domNode.style.backgroundColor = "darkgoldenrod";
+				this.style.backgroundColor = "darkgoldenrod";
 			} else {
-				this.domNode.style.backgroundColor = "orange";
+				this.style.backgroundColor = "orange";
 			}
 		},
 		beforeDeactivate: function ( /*nextView*/ ) {
@@ -33,8 +33,8 @@ define([], function () {
 			//	(nextView ? nextView.id : "") + "]");
 			this._afterDeactivateCallCount++;
 		},
-		destroy: function () {
-			//console.log("app-view:", " in [" + this.viewName + "] destroy called for [" + this.id + "]");
+		beforeDestroy: function () {
+			//console.log("app-view:", " in [" + this.viewName + "] beforeDestroy called for [" + this.id + "]");
 		}
 	};
 });

--- a/tests/unit/multipleAndNestedViewsActivateCalls/Test.js
+++ b/tests/unit/multipleAndNestedViewsActivateCalls/Test.js
@@ -244,7 +244,7 @@ define([
 					//	checkNestedNodeVisibility(multipleAndNestedViewsActivateCallsApp1Content,
 					// 		multipleAndNestedViewsActivateCallsApp1P2V1);
 					assert.isNull(multipleAndNestedViewsActivateCallsApp1P2V2);
-					assert.isNull(testApp.children.content.domNode.parentNode);
+					assert.isNull(testApp.childViews.content.parentNode);
 
 
 
@@ -312,7 +312,7 @@ define([
 					//	checkNestedNodeVisibility(multipleAndNestedViewsActivateCallsApp1Content,
 					// multipleAndNestedViewsActivateCallsApp1P2V2);
 					assert.isNull(multipleAndNestedViewsActivateCallsApp1P2V2);
-					assert.isNull(multipleAndNestedViewsActivateCallsApp1P2S1View.domNode.parentNode);
+					assert.isNull(multipleAndNestedViewsActivateCallsApp1P2S1View.parentNode);
 
 
 

--- a/tests/unit/multipleAndNestedViewsActivateCalls/TestConstraints.js
+++ b/tests/unit/multipleAndNestedViewsActivateCalls/TestConstraints.js
@@ -246,7 +246,7 @@ define([
 					//	checkNestedNodeVisibility(multipleAndNestedViewsActivateCallsApp1Content,
 					// 		multipleAndNestedViewsActivateCallsApp1P2V1);
 					assert.isNull(multipleAndNestedViewsActivateCallsApp1P2V2);
-					assert.isNull(testApp.children.contentCons.domNode.parentNode);
+					assert.isNull(testApp.childViews.contentCons.parentNode);
 
 
 
@@ -317,7 +317,7 @@ define([
 					//	checkNestedNodeVisibility(multipleAndNestedViewsActivateCallsApp1Content,
 					// multipleAndNestedViewsActivateCallsApp1P2V2);
 					assert.isNull(multipleAndNestedViewsActivateCallsApp1P2V2);
-					assert.isNull(multipleAndNestedViewsActivateCallsApp1P2S1View.domNode.parentNode);
+					assert.isNull(multipleAndNestedViewsActivateCallsApp1P2S1View.parentNode);
 
 
 

--- a/tests/unit/multipleAndNestedViewsActivateCalls/parentController1.js
+++ b/tests/unit/multipleAndNestedViewsActivateCalls/parentController1.js
@@ -6,7 +6,7 @@ define([], function () {
 		_afterActivateCallCount: 0,
 		_afterDeactivateCallCount: 0,
 		init: function () {
-			this.domNode.name = this.id;
+			this.name = this.id;
 		},
 		beforeActivate: function () {
 			this._beforeActivateCallCount++;
@@ -20,8 +20,8 @@ define([], function () {
 		afterDeactivate: function () {
 			this._afterDeactivateCallCount++;
 		},
-		destroy: function () {
-			//console.log("app-view:", " in [" + this.viewName + "] destroy called for [" + this.id + "]");
+		beforeDestroy: function () {
+			//console.log("app-view:", " in [" + this.viewName + "] beforeDestroy called for [" + this.id + "]");
 		}
 	};
 });

--- a/tests/unit/multipleAndNestedViewsActivateCalls/viewController1.js
+++ b/tests/unit/multipleAndNestedViewsActivateCalls/viewController1.js
@@ -7,7 +7,7 @@ define([], function () {
 		_afterDeactivateCallCount: 0,
 		tempName: "",
 		init: function () {
-			this.domNode.name = this.id;
+			this.name = this.id;
 		},
 		beforeActivate: function () {
 			this._beforeActivateCallCount++;
@@ -21,9 +21,9 @@ define([], function () {
 		afterDeactivate: function () {
 			this._afterDeactivateCallCount++;
 		},
-		// for now destroy function is required or an error can occur during dapp-unload-app or dapp-unload-view
-		destroy: function () {
-			//console.log("app-view:", " in [" + this.viewName + "] destroy called for [" + this.id + "]");
+		// for now beforeDestroy function is required or an error can occur during dapp-unload-app or dapp-unload-view
+		beforeDestroy: function () {
+			//console.log("app-view:", " in [" + this.viewName + "] beforeDestroy called for [" + this.id + "]");
 		}
 	};
 });

--- a/tests/unit/nestedViewsActivateCalls/parentController1.js
+++ b/tests/unit/nestedViewsActivateCalls/parentController1.js
@@ -7,7 +7,7 @@ define([], function () {
 		afterActivateCallCount: 0,
 		afterDeactivateCallCount: 0,
 		init: function () {
-			this.domNode.name = this.id;
+			this.name = this.id;
 		},
 		beforeActivate: function ( /*previousView, viewData*/ ) {
 			//console.log("app-view:", "beforeActivate called for [" + this.viewName + "] with previousView.id =[" +
@@ -29,8 +29,8 @@ define([], function () {
 			//	(nextView ? nextView.id : "") + "]");
 			this.afterDeactivateCallCount++;
 		},
-		destroy: function () {
-			//console.log("app-view:", " in [" + this.viewName + "] destroy called for [" + this.id + "]");
+		beforeDestroy: function () {
+			//console.log("app-view:", " in [" + this.viewName + "] beforeDestroy called for [" + this.id + "]");
 		}
 	};
 });

--- a/tests/unit/nestedViewsActivateCalls/viewController1.js
+++ b/tests/unit/nestedViewsActivateCalls/viewController1.js
@@ -9,7 +9,7 @@ define([ /*"dojo/dom", "dojo/on", "delite/register", "dcl/dcl", "dapp/View"*/ ],
 			afterActivateCallCount: 0,
 			afterDeactivateCallCount: 0,
 			init: function () {
-				this.domNode.name = this.id;
+				this.name = this.id;
 			},
 			beforeActivate: function ( /*previousView, viewData*/ ) {
 				//console.log("app-view:", "beforeActivate called for [" + this.viewName +
@@ -31,8 +31,8 @@ define([ /*"dojo/dom", "dojo/on", "delite/register", "dcl/dcl", "dapp/View"*/ ],
 				//	"] with previousView.id =[" + (nextView ? nextView.id : "") + "]");
 				this.afterDeactivateCallCount++;
 			},
-			destroy: function () {
-				//console.log("app-view:", " in [" + this.viewName + "] destroy called for [" + this.id + "]");
+			beforeDestroy: function () {
+				//console.log("app-view:", " in [" + this.viewName + "] beforeDestroy called for [" + this.id + "]");
 			}
 		};
 		//); // for dcl view attempt...

--- a/tests/unit/nestedViewsActivateCalls/viewController1ViewExt.js
+++ b/tests/unit/nestedViewsActivateCalls/viewController1ViewExt.js
@@ -2,53 +2,59 @@
 define(["dojo/dom", "dojo/on", "delite/register", "dcl/dcl", "dapp/View"],
 	function (dom, on, register, dcl, View) {
 		return dcl([View], {
-				//	define([ /*"dojo/dom", "dojo/on", "delite/register", "dcl/dcl", "dapp/View"*/ ],
-				//	function ( /*dom, on, register, dcl, View*/ ) {
-				//return {
-				name: "",
-				beforeActivateCallCount: 0,
-				beforeDeactivateCallCount: 0,
-				afterActivateCallCount: 0,
-				afterDeactivateCallCount: 0,
-				init: function () {
-					if (this.domNode) {
-						this.domNode.name = this.id;
-					} else {
-						this.name = this.id;
-					}
-				},
-				//beforeActivate: function ( /*previousView, viewData*/ ) {
-				//	//console.log("app-view:", "beforeActivate called for [" + this.viewName +
-				//	//"] with previousView.id =[" + (previousView ? previousView.id : "") + "] with viewData=",
-				//  //viewData);
-				//	this.beforeActivateCallCount++;
-				//},
-				beforeActivate: dcl.superCall(function (sup) {
-					return function () {
-						this.beforeActivateCallCount++;
-						return sup.call(this);
-					};
-				}),
+			//	define([ /*"dojo/dom", "dojo/on", "delite/register", "dcl/dcl", "dapp/View"*/ ],
+			//	function ( /*dom, on, register, dcl, View*/ ) {
+			//return {
+			name: "",
+			beforeActivateCallCount: 0,
+			beforeDeactivateCallCount: 0,
+			afterActivateCallCount: 0,
+			afterDeactivateCallCount: 0,
 
-				beforeDeactivate: function ( /*nextView, viewData*/ ) {
-					//console.log("app-view:", "beforeDeactivate called for [" + this.viewName +
-					//	"] with previousView.id =[" + (nextView ? nextView.id : "") + "]");
-					this.beforeDeactivateCallCount++;
-				},
-				afterActivate: function ( /*previousView, viewData*/ ) {
-					//console.log("app-view:", "afterActivate called for [" + this.viewName +
-					// "] with previousView.id =[" +
-					//	(previousView ? previousView.id : "") + "] with viewData=", viewData);
-					this.afterActivateCallCount++;
-				},
-				afterDeactivate: function ( /*nextView, viewData*/ ) {
-					//console.log("app-view:", "afterDeactivate called for [" + this.viewName +
-					//	"] with previousView.id =[" + (nextView ? nextView.id : "") + "]");
-					this.afterDeactivateCallCount++;
-				},
-				destroy: function () {
-					//console.log("app-view:", " in [" + this.viewName + "] destroy called for [" + this.id + "]");
+			setupViewParams: dcl.superCall(function (sup) {
+				return function (controller) {
+					var viewParams = sup.call(this);
+					//dcl.mix(viewParams, this);
+					this._safeMixIntoNode(viewParams, this);
+					if (controller) { // mix controller after this view extension
+						dcl.mix(viewParams, controller);
+					}
+					return viewParams;
+				};
+			}),
+
+			init: function () {
+				if (this) {
+					this.name = this.id;
+				} else {
+					this.name = this.id;
 				}
-			} //;
-		); // for dcl view attempt...
+			},
+			beforeActivate: function ( /*nextView, viewData*/ ) {
+				//console.log("app-view:", "beforeActivate called for [" + this.viewName +
+				//"] with previousView.id =[" + (previousView ? previousView.id : "") + "] with viewData=",
+				//viewData);
+				this.beforeActivateCallCount++;
+			},
+
+			beforeDeactivate: function ( /*nextView, viewData*/ ) {
+				//console.log("app-view:", "beforeDeactivate called for [" + this.viewName +
+				//	"] with previousView.id =[" + (nextView ? nextView.id : "") + "]");
+				this.beforeDeactivateCallCount++;
+			},
+			afterActivate: function ( /*previousView, viewData*/ ) {
+				//console.log("app-view:", "afterActivate called for [" + this.viewName +
+				// "] with previousView.id =[" +
+				//	(previousView ? previousView.id : "") + "] with viewData=", viewData);
+				this.afterActivateCallCount++;
+			},
+			afterDeactivate: function ( /*nextView, viewData*/ ) {
+				//console.log("app-view:", "afterDeactivate called for [" + this.viewName +
+				//	"] with previousView.id =[" + (nextView ? nextView.id : "") + "]");
+				this.afterDeactivateCallCount++;
+			},
+			beforeDestroy: function () {
+				//console.log("app-view:", " in [" + this.viewName + "] beforeDestroy called for [" + this.id + "]");
+			}
+		}); // for dcl view attempt...
 	});

--- a/tests/unit/nlsLabels/viewController1.js
+++ b/tests/unit/nlsLabels/viewController1.js
@@ -7,7 +7,7 @@ define([], function () {
 		_afterActivateCallCount: 0,
 		_afterDeactivateCallCount: 0,
 		init: function () {
-			this.domNode.name = this.id;
+			this.name = this.id;
 		},
 		beforeActivate: function (previousView, viewData) {
 			//console.log("app-view:", "beforeActivate called for [" + this.viewName + "] with previousView.id =[" +
@@ -30,9 +30,9 @@ define([], function () {
 			//	(nextView ? nextView.id : "") + "]");
 			this._afterDeactivateCallCount++;
 		},
-		// for now destroy function is required or an error can occur during dapp-unload-app or dapp-unload-view
-		destroy: function () {
-			//console.log("app-view:", " in [" + this.viewName + "] destroy called for [" + this.id + "]");
+		// for now beforeDestroy function is required or an error can occur during dapp-unload-app or dapp-unload-view
+		beforeDestroy: function () {
+			//console.log("app-view:", " in [" + this.viewName + "] beforeDestroy called for [" + this.id + "]");
 		}
 	};
 });

--- a/tests/unit/sidePaneViewsActivateCalls/Test.js
+++ b/tests/unit/sidePaneViewsActivateCalls/Test.js
@@ -154,7 +154,7 @@ define([
 				var sp1right2content = sp1right2View.containerNode;
 				assert.isNotNull(sp1right2content, "sp1right2content must be here");
 				//	checkNodeVisibile(sp1right2content);
-				assert.isTrue(sp1right2View.domNode.style.display === "none");
+				assert.isTrue(sp1right2View.style.display === "none");
 				assert.isTrue(sp1rightPaneElem.style.display === "none");
 			});
 		},

--- a/tests/unit/sidePaneViewsActivateCalls/centerController1.js
+++ b/tests/unit/sidePaneViewsActivateCalls/centerController1.js
@@ -6,16 +6,16 @@ define([], function () {
 		_afterActivateCallCount: 0,
 		_afterDeactivateCallCount: 0,
 		init: function () {
-			this.domNode.name = this.id;
+			this.name = this.id;
 		},
 		beforeActivate: function ( /*previousView, viewData*/ ) {
 			//console.log("app-view:", "beforeActivate called for [" + this.viewName + "] with previousView.id =[" +
 			//	(previousView ? previousView.id : "") + "] with viewData=", viewData);
 			this._beforeActivateCallCount++;
 			if (this.id === "center1") {
-				this.domNode.style.backgroundColor = "cyan";
+				this.style.backgroundColor = "cyan";
 			} else {
-				this.domNode.style.backgroundColor = "green";
+				this.style.backgroundColor = "green";
 			}
 		},
 		beforeDeactivate: function ( /*nextView*/ ) {
@@ -33,8 +33,8 @@ define([], function () {
 			//	(nextView ? nextView.id : "") + "]");
 			this._afterDeactivateCallCount++;
 		},
-		destroy: function () {
-			//console.log("app-view:", " in [" + this.viewName + "] destroy called for [" + this.id + "]");
+		beforeDestroy: function () {
+			//console.log("app-view:", " in [" + this.viewName + "] beforeDestroy called for [" + this.id + "]");
 		}
 	};
 });

--- a/tests/unit/sidePaneViewsActivateCalls/footerController1.js
+++ b/tests/unit/sidePaneViewsActivateCalls/footerController1.js
@@ -6,7 +6,7 @@ define([], function () {
 		_afterActivateCallCount: 0,
 		_afterDeactivateCallCount: 0,
 		init: function () {
-			this.domNode.name = this.id;
+			this.name = this.id;
 		},
 		beforeActivate: function ( /*previousView, viewData*/ ) {
 			//console.log("app-view:", "beforeActivate called for [" + this.viewName + "] with previousView.id =[" +
@@ -28,8 +28,8 @@ define([], function () {
 			//	(nextView ? nextView.id : "") + "]");
 			this._afterDeactivateCallCount++;
 		},
-		destroy: function () {
-			//console.log("app-view:", " in [" + this.viewName + "] destroy called for [" + this.id + "]");
+		beforeDestroy: function () {
+			//console.log("app-view:", " in [" + this.viewName + "] beforeDestroy called for [" + this.id + "]");
 		}
 	};
 });

--- a/tests/unit/sidePaneViewsActivateCalls/headerController1.js
+++ b/tests/unit/sidePaneViewsActivateCalls/headerController1.js
@@ -6,7 +6,7 @@ define([], function () {
 		_afterActivateCallCount: 0,
 		_afterDeactivateCallCount: 0,
 		init: function () {
-			this.domNode.name = this.id;
+			this.name = this.id;
 		},
 		beforeActivate: function ( /*previousView, viewData*/ ) {
 			//console.log("app-view:", "beforeActivate called for [" + this.viewName + "] with previousView.id =[" +
@@ -28,8 +28,8 @@ define([], function () {
 			//	(nextView ? nextView.id : "") + "]");
 			this._afterDeactivateCallCount++;
 		},
-		destroy: function () {
-			//console.log("app-view:", " in [" + this.viewName + "] destroy called for [" + this.id + "]");
+		beforeDestroy: function () {
+			//console.log("app-view:", " in [" + this.viewName + "] beforeDestroy called for [" + this.id + "]");
 		}
 	};
 });

--- a/tests/unit/sidePaneViewsActivateCalls/leftController1.js
+++ b/tests/unit/sidePaneViewsActivateCalls/leftController1.js
@@ -6,16 +6,16 @@ define([], function () {
 		_afterActivateCallCount: 0,
 		_afterDeactivateCallCount: 0,
 		init: function () {
-			this.domNode.name = this.id;
+			this.name = this.id;
 		},
 		beforeActivate: function ( /*previousView, viewData*/ ) {
 			//console.log("app-view:", "beforeActivate called for [" + this.viewName + "] with previousView.id =[" +
 			//	(previousView ? previousView.id : "") + "] with viewData=", viewData);
 			this._beforeActivateCallCount++;
 			if (this.id === "right1") {
-				this.domNode.style.backgroundColor = "darkgoldenrod";
+				this.style.backgroundColor = "darkgoldenrod";
 			} else {
-				this.domNode.style.backgroundColor = "orange";
+				this.style.backgroundColor = "orange";
 			}
 		},
 		beforeDeactivate: function ( /*nextView*/ ) {
@@ -33,8 +33,8 @@ define([], function () {
 			//	(nextView ? nextView.id : "") + "]");
 			this._afterDeactivateCallCount++;
 		},
-		destroy: function () {
-			//console.log("app-view:", " in [" + this.viewName + "] destroy called for [" + this.id + "]");
+		beforeDestroy: function () {
+			//console.log("app-view:", " in [" + this.viewName + "] beforeDestroy called for [" + this.id + "]");
 		}
 	};
 });

--- a/tests/unit/sidePaneViewsActivateCalls/parentController1.js
+++ b/tests/unit/sidePaneViewsActivateCalls/parentController1.js
@@ -6,7 +6,7 @@ define([], function () {
 		_afterActivateCallCount: 0,
 		_afterDeactivateCallCount: 0,
 		init: function () {
-			this.domNode.name = this.id;
+			this.name = this.id;
 		},
 		beforeActivate: function ( /*previousView, viewData*/ ) {
 			//console.log("app-view:", "beforeActivate called for [" + this.viewName + "] with previousView.id =[" +
@@ -28,8 +28,8 @@ define([], function () {
 			//	(nextView ? nextView.id : "") + "]");
 			this._afterDeactivateCallCount++;
 		},
-		destroy: function () {
-			//console.log("app-view:", " in [" + this.viewName + "] destroy called for [" + this.id + "]");
+		beforeDestroy: function () {
+			//console.log("app-view:", " in [" + this.viewName + "] beforeDestroy called for [" + this.id + "]");
 		}
 	};
 });

--- a/tests/unit/sidePaneViewsActivateCalls/rightController1.js
+++ b/tests/unit/sidePaneViewsActivateCalls/rightController1.js
@@ -6,16 +6,16 @@ define([], function () {
 		_afterActivateCallCount: 0,
 		_afterDeactivateCallCount: 0,
 		init: function () {
-			this.domNode.name = this.id;
+			this.name = this.id;
 		},
 		beforeActivate: function ( /*previousView, viewData*/ ) {
 			//console.log("app-view:", "beforeActivate called for [" + this.viewName + "] with previousView.id =[" +
 			//	(previousView ? previousView.id : "") + "] with viewData=", viewData);
 			this._beforeActivateCallCount++;
 			if (this.id === "right1") {
-				this.domNode.style.backgroundColor = "darkgoldenrod";
+				this.style.backgroundColor = "darkgoldenrod";
 			} else {
-				this.domNode.style.backgroundColor = "orange";
+				this.style.backgroundColor = "orange";
 			}
 		},
 		beforeDeactivate: function ( /*nextView*/ ) {
@@ -33,8 +33,8 @@ define([], function () {
 			//	(nextView ? nextView.id : "") + "]");
 			this._afterDeactivateCallCount++;
 		},
-		destroy: function () {
-			//console.log("app-view:", " in [" + this.viewName + "] destroy called for [" + this.id + "]");
+		beforeDestroy: function () {
+			//console.log("app-view:", " in [" + this.viewName + "] beforeDestroy called for [" + this.id + "]");
 		}
 	};
 });

--- a/tests/unit/transitionTypes/config.json
+++ b/tests/unit/transitionTypes/config.json
@@ -38,7 +38,7 @@
 	],
 
 	"appLogging": {
-		"logAll": 1
+		"logAll": 0
 	},
 	"alwaysUseDefaultView" : true, // ignore any url hash when starting the app
 	"defaultView": "header+aaa+footer",

--- a/tests/unit/transitionTypes/footer.js
+++ b/tests/unit/transitionTypes/footer.js
@@ -8,18 +8,18 @@ define(["dojo/dom", "dojo/on", "delite/register"], function (dom, on, register) 
 		dddsel: false,
 
 		setSelection: function (sel) {
-			this.domNode.aaasel = false;
-			this.domNode.bbbsel = false;
-			this.domNode.cccsel = false;
-			this.domNode.dddsel = false;
+			this.aaasel = false;
+			this.bbbsel = false;
+			this.cccsel = false;
+			this.dddsel = false;
 			if (sel === "aaa") {
-				this.domNode.aaasel = true;
+				this.aaasel = true;
 			} else if (sel === "bbb") {
-				this.domNode.bbbsel = true;
+				this.bbbsel = true;
 			} else if (sel === "ccc") {
-				this.domNode.cccsel = true;
+				this.cccsel = true;
 			} else if (sel === "ddd") {
-				this.domNode.dddsel = true;
+				this.dddsel = true;
 			}
 		},
 
@@ -37,8 +37,8 @@ define(["dojo/dom", "dojo/on", "delite/register"], function (dom, on, register) 
 			console.log("in home.js beforeDeactivate called previousView=", previousView);
 		},
 		afterActivate: function (previousView) {
-			if (this.domNode.ownerDocument.getElementById("vs")) {
-				var vsNode = this.domNode.ownerDocument.getElementById("vs");
+			if (this.ownerDocument.getElementById("vs")) {
+				var vsNode = this.ownerDocument.getElementById("vs");
 				var sel = vsNode.selectedChildId;
 				this.setSelection(sel);
 			}

--- a/tests/unit/transitionTypes/footer3.js
+++ b/tests/unit/transitionTypes/footer3.js
@@ -7,18 +7,18 @@ define(["dojo/dom", "dojo/on", "delite/register"], function (dom, on, register) 
 		dddsel: false,
 
 		setSelection: function (sel) {
-			this.domNode.aaasel = false;
-			this.domNode.bbbsel = false;
-			this.domNode.cccsel = false;
-			this.domNode.dddsel = false;
+			this.aaasel = false;
+			this.bbbsel = false;
+			this.cccsel = false;
+			this.dddsel = false;
 			if (sel === "aaa") {
-				this.domNode.aaasel = true;
+				this.aaasel = true;
 			} else if (sel === "bbb") {
-				this.domNode.bbbsel = true;
+				this.bbbsel = true;
 			} else if (sel === "ccc") {
-				this.domNode.cccsel = true;
+				this.cccsel = true;
 			} else if (sel === "ddd") {
-				this.domNode.dddsel = true;
+				this.dddsel = true;
 			}
 		},
 
@@ -35,8 +35,8 @@ define(["dojo/dom", "dojo/on", "delite/register"], function (dom, on, register) 
 			//console.log("in footer3.js beforeDeactivate called previousView=", previousView);
 		},
 		afterActivate: function (previousView) {
-			if (this.domNode.ownerDocument.getElementById("vs")) {
-				var vsNode = this.domNode.ownerDocument.getElementById("vs");
+			if (this.ownerDocument.getElementById("vs")) {
+				var vsNode = this.ownerDocument.getElementById("vs");
 				var sel = vsNode.selectedChildId;
 				this.setSelection(sel);
 			}

--- a/tests/unit/transitionTypes/footerShow.js
+++ b/tests/unit/transitionTypes/footerShow.js
@@ -7,18 +7,18 @@ define(["dojo/dom", "dojo/on", "delite/register"], function (dom, on, register) 
 		dddsel: false,
 
 		setSelection: function (sel) {
-			this.domNode.aaasel = false;
-			this.domNode.bbbsel = false;
-			this.domNode.cccsel = false;
-			this.domNode.dddsel = false;
+			this.aaasel = false;
+			this.bbbsel = false;
+			this.cccsel = false;
+			this.dddsel = false;
 			if (sel === "aaa") {
-				this.domNode.aaasel = true;
+				this.aaasel = true;
 			} else if (sel === "bbb") {
-				this.domNode.bbbsel = true;
+				this.bbbsel = true;
 			} else if (sel === "ccc") {
-				this.domNode.cccsel = true;
+				this.cccsel = true;
 			} else if (sel === "ddd") {
-				this.domNode.dddsel = true;
+				this.dddsel = true;
 			}
 		},
 
@@ -36,8 +36,8 @@ define(["dojo/dom", "dojo/on", "delite/register"], function (dom, on, register) 
 			//console.log("in footerShow.js beforeDeactivate called previousView=", previousView);
 		},
 		afterActivate: function (previousView) {
-			if (this.domNode.ownerDocument.getElementById("vs")) {
-				var vsNode = this.domNode.ownerDocument.getElementById("vs");
+			if (this.ownerDocument.getElementById("vs")) {
+				var vsNode = this.ownerDocument.getElementById("vs");
 				var sel = vsNode.selectedChildId;
 				this.setSelection(sel);
 			}

--- a/tests/unit/transitionVisibility/viewController1.js
+++ b/tests/unit/transitionVisibility/viewController1.js
@@ -3,7 +3,7 @@ define([], function () {
 	return {
 		name: "",
 		init: function () {
-			this.domNode.name = this.id;
+			this.name = this.id;
 		},
 		beforeActivate: function ( /*previousView, viewData*/ ) {
 			//console.log("app-view:", "beforeActivate called for [" + this.viewName + "] with previousView.id =[" +
@@ -25,8 +25,8 @@ define([], function () {
 			//	(nextView ? nextView.id : "") + "]");
 			this._afterDeactivateCallCount++;
 		},
-		destroy: function () {
-			//console.log("app-view:", " in [" + this.viewName + "] destroy called for [" + this.id + "]");
+		beforeDestroy: function () {
+			//console.log("app-view:", " in [" + this.viewName + "] beforeDestroy called for [" + this.id + "]");
 		}
 	};
 });

--- a/tests/unit/viewDataAndParams/parentController1.js
+++ b/tests/unit/viewDataAndParams/parentController1.js
@@ -6,7 +6,7 @@ define([], function () {
 		_afterActivateCallCount: 0,
 		_afterDeactivateCallCount: 0,
 		init: function () {
-			this.domNode.name = this.id;
+			this.name = this.id;
 		},
 		beforeActivate: function (previousView, viewData) {
 			//console.log("app-view:", "beforeActivate called for [" + this.viewName + "] with previousView.id =[" +
@@ -29,8 +29,8 @@ define([], function () {
 			//	(nextView ? nextView.id : "") + "]");
 			this._afterDeactivateCallCount++;
 		},
-		destroy: function () {
-			//console.log("app-view:", " in [" + this.viewName + "] destroy called for [" + this.id + "]");
+		beforeDestroy: function () {
+			//console.log("app-view:", " in [" + this.viewName + "] beforeDestroy called for [" + this.id + "]");
 		}
 	};
 });

--- a/tests/unit/viewDataAndParams/viewController1.js
+++ b/tests/unit/viewDataAndParams/viewController1.js
@@ -7,7 +7,7 @@ define([], function () {
 		_afterActivateCallCount: 0,
 		_afterDeactivateCallCount: 0,
 		init: function () {
-			this.domNode.name = this.id;
+			this.name = this.id;
 		},
 		beforeActivate: function (previousView, viewData) {
 			//console.log("app-view:", "beforeActivate called for [" + this.viewName + "] with previousView.id =[" +
@@ -30,9 +30,9 @@ define([], function () {
 			//	(nextView ? nextView.id : "") + "]");
 			this._afterDeactivateCallCount++;
 		},
-		// for now destroy function is required or an error can occur during dapp-unload-app or dapp-unload-view
-		destroy: function () {
-			//console.log("app-view:", " in [" + this.viewName + "] destroy called for [" + this.id + "]");
+		// for now beforeDestroy function is required or an error can occur during dapp-unload-app or dapp-unload-view
+		beforeDestroy: function () {
+			//console.log("app-view:", " in [" + this.viewName + "] beforeDestroy called for [" + this.id + "]");
 		}
 	};
 });

--- a/tests/unit/viewLayout/viewController1.js
+++ b/tests/unit/viewLayout/viewController1.js
@@ -3,7 +3,7 @@ define([], function () {
 	return {
 		name: "",
 		init: function () {
-			this.domNode.name = this.id;
+			this.name = this.id;
 			var tempName = "";
 			if (this.id === "viewLayoutApp1Home2") {
 				setTimeout(function () {
@@ -33,8 +33,8 @@ define([], function () {
 			//	(nextView ? nextView.id : "") + "]");
 			this._afterDeactivateCallCount++;
 		},
-		destroy: function () {
-			//console.log("app-view:", " in [" + this.viewName + "] destroy called for [" + this.id + "]");
+		beforeDestroy: function () {
+			//console.log("app-view:", " in [" + this.viewName + "] beforeDestroy called for [" + this.id + "]");
 		}
 	};
 });

--- a/utils/view.js
+++ b/utils/view.js
@@ -172,8 +172,8 @@ define(["dcl/dcl"], function (dcl) {
 				if (app.autoUnloadCount) {
 					child.transitionCount = 0;
 					// add code to bump the transitionCounter to see when to unload other child views
-					for (var otherChildKey in view.children) {
-						var otherChild = view.children[otherChildKey];
+					for (var otherChildKey in view.childViews) {
+						var otherChild = view.childViews[otherChildKey];
 						var otherChildConstraint = otherChild.constraint;
 						var childtype = typeof (otherChildConstraint);
 						var childhash = (childtype === "string" || childtype === "number") ? otherChildConstraint :
@@ -223,7 +223,7 @@ define(["dcl/dcl"], function (dcl) {
 				var nextChildId = "";
 				for (var item in parts) {
 					var childId = nextChildId + parts[item];
-					view = view.children[childId];
+					view = view.childViews[childId];
 					nextChildId = childId + "_";
 				}
 				return view;
@@ -372,7 +372,7 @@ define(["dcl/dcl"], function (dcl) {
 				var nextChildId = "";
 				for (var item in parts) {
 					var childId = nextChildId + parts[item];
-					view = view.children[childId];
+					view = view.childViews[childId];
 					nextChildId = childId + "_";
 				}
 				return view;
@@ -453,6 +453,8 @@ define(["dcl/dcl"], function (dcl) {
 
 		register: function (constraint) {
 			// if the constraint has already been registered we don't care about it...
+			//TODO: need to look into this code, it does not seem to be doing anything since the constraint is always
+			// a string and never has an __hash
 			var type = typeof (constraint);
 			if (!constraint.__hash && type !== "string" && type !== "number") {
 				var match = null;

--- a/viewFactory.js
+++ b/viewFactory.js
@@ -1,0 +1,23 @@
+define(["require", "dojo/when", "dcl/dcl", "dojo/Deferred"],
+	function (require, when, dcl, Deferred) {
+		return function (viewParams) {
+			var viewType = viewParams.viewType;
+			var createDef = new Deferred();
+			require([viewType ? viewType : "./View"], function (View) {
+				var v = new View(viewParams);
+				if (v.start) {
+					v.start().then(function (newView) {
+						//ELC TRY THIS:
+						if (newView.domNode) {
+							newView = newView.domNode;
+						}
+						createDef.resolve(newView);
+					});
+				} else {
+					var newView = v;
+					createDef.resolve(newView);
+				}
+			});
+			return createDef;
+		};
+	});


### PR DESCRIPTION
... I added a viewFactory to create the view and return the view domNode since that seemed to make sense. There were also a couple of view variable names which had to change to avoid conflicts with the domNode, parentNode became viewParentNode, and children became childViews, destroy became beforeDestroy.  Most tests were updated to remove .domNode when setting things on the view and make updates for the variable name changes.
